### PR TITLE
Add production verification route helper

### DIFF
--- a/docs/testing/ui-test-cases.md
+++ b/docs/testing/ui-test-cases.md
@@ -4,7 +4,7 @@
 
 This suite verifies the main public user flows with deterministic fixture data, viewport coverage, and screenshot evidence.
 
-## Covered Routes
+## Fixture-Covered Routes
 
 - `home`
 - `#calendar?member=M002`
@@ -27,7 +27,7 @@ This suite verifies the main public user flows with deterministic fixture data, 
 ### 2. Search To Single-Member Calendar
 
 - Type a lawmaker query from the home command panel.
-- Verify hash navigation to `#calendar?member=M002`.
+- Verify hash navigation to `#calendar?member=M002` in the fixture-backed UI test run.
 - Verify the single-member calendar loads the lazy vote record detail.
 - Confirm the calendar auto-scrolls to the latest visible dates.
 - Capture `.artifacts/ui/<viewport>/calendar-single.png`.
@@ -45,8 +45,44 @@ This suite verifies the main public user flows with deterministic fixture data, 
 - Switch from `개인 분석` to `VS 비교`.
 - Select a second member in the compare search field.
 - Verify the compare summary and both member identities are visible.
-- Open the compare deep link directly and verify the compare tab remains selected.
+- Open the fixture compare deep link directly and verify the compare tab remains selected.
 - Capture `.artifacts/ui/<viewport>/calendar-compare.png`.
+
+## Production Verification Routes
+
+The fixture routes above are only for local UI automation. Shared verification against GitHub Pages or the published data repository must resolve live member IDs from the current manifest instead of reusing `M002` or `M001`.
+
+Resolve the current production URLs with:
+
+```bash
+npm run resolve:production-ui-routes
+```
+
+The command fetches `manifests/latest.json`, follows the published `member_activity_calendar.json` path, sorts current assembly members by `name` and `memberId`, probes published member detail files, and prints the exact single-member and compare URLs that are live for the current snapshot.
+
+When leaving shared verification evidence, include:
+
+- `snapshotId`
+- `single.url`
+- `compare.url`
+- screenshot evidence for the single-member header and compare ratio table
+
+Use a shared comment shape that leaves the exact command output easy to audit:
+
+```md
+## verified-shared
+
+- ref: `<commit-or-branch>`
+- validation:
+  - `npm test -- tests/ingest/resolve-production-ui-routes.test.ts`
+  - `npm run resolve:production-ui-routes`
+- snapshotId: `<snapshotId>`
+- single.url: `<single.url>`
+- compare.url: `<compare.url>`
+- screenshots:
+  - `<single header screenshot path or URL>`
+  - `<compare ratio table screenshot path or URL>`
+```
 
 ## Execution
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ingest:live": "npm run ingest:live --workspace @lawmaker-monitor/ingest",
     "mirror:documents": "npm run mirror:documents --workspace @lawmaker-monitor/ingest",
     "monitor:sources": "npm run monitor:sources --workspace @lawmaker-monitor/ingest",
+    "resolve:production-ui-routes": "node ./scripts/resolve-production-ui-routes.mjs",
     "test": "vitest run",
     "test:ui": "node ./scripts/run-ui-tests.mjs",
     "test:watch": "vitest",

--- a/scripts/resolve-production-ui-routes.mjs
+++ b/scripts/resolve-production-ui-routes.mjs
@@ -1,0 +1,162 @@
+import { resolve as resolvePath } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_APP_BASE_URL = process.env.APP_BASE_URL ?? "https://kuil09.github.io/lawmaker-monitor/";
+const DEFAULT_DATA_REPO_BASE_URL =
+  process.env.DATA_REPO_BASE_URL ?? "https://kuil09.github.io/lawmaker-monitor-data/";
+
+function normalizeBaseUrl(value) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+async function fetchJson(fetchImpl, url) {
+  const response = await fetchImpl(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url} (${response.status}).`);
+  }
+
+  return response.json();
+}
+
+async function urlExists(fetchImpl, url) {
+  let response;
+
+  try {
+    response = await fetchImpl(url, { method: "HEAD" });
+  } catch {
+    response = null;
+  }
+
+  if (!response || response.status === 405 || response.status === 501) {
+    response = await fetchImpl(url);
+  }
+
+  return response.ok;
+}
+
+export function compareVerificationMembers(left, right) {
+  return left.name.localeCompare(right.name, "ko-KR") || left.memberId.localeCompare(right.memberId);
+}
+
+export async function pickVerificationMembers(
+  members,
+  {
+    dataRepoBaseUrl,
+    fetchImpl = globalThis.fetch
+  } = {}
+) {
+  if (!dataRepoBaseUrl) {
+    throw new Error("dataRepoBaseUrl is required.");
+  }
+
+  const candidates = members
+    .filter(
+      (member) =>
+        typeof member?.memberId === "string" &&
+        member.memberId.length > 0 &&
+        typeof member?.name === "string" &&
+        member.name.length > 0 &&
+        typeof member?.voteRecordsPath === "string" &&
+        member.voteRecordsPath.length > 0
+    )
+    .sort(compareVerificationMembers)
+    .map((member) => ({
+      memberId: member.memberId,
+      name: member.name,
+      party: member.party ?? member.partyName ?? null,
+      voteRecordsPath: member.voteRecordsPath,
+      detailUrl: new URL(member.voteRecordsPath, dataRepoBaseUrl).toString()
+    }));
+
+  const selectedMembers = [];
+
+  for (const candidate of candidates) {
+    if (!(await urlExists(fetchImpl, candidate.detailUrl))) {
+      continue;
+    }
+
+    selectedMembers.push(candidate);
+
+    if (selectedMembers.length === 2) {
+      return selectedMembers;
+    }
+  }
+
+  throw new Error(
+    `Unable to find two published members with resolvable detail files. Checked ${candidates.length} candidates.`
+  );
+}
+
+export function buildVerificationRoutes({
+  appBaseUrl,
+  dataRepoBaseUrl,
+  manifestUrl,
+  calendarUrl,
+  snapshotId,
+  updatedAt,
+  selectedMembers
+}) {
+  const [primaryMember, secondaryMember] = selectedMembers;
+  const singleHash = `#calendar?member=${encodeURIComponent(primaryMember.memberId)}`;
+  const compareHash =
+    `#calendar?member=${encodeURIComponent(primaryMember.memberId)}` +
+    `&compare=${encodeURIComponent(secondaryMember.memberId)}&view=compare`;
+
+  return {
+    snapshotId,
+    updatedAt,
+    selectionRule:
+      "Sort assembly members by name (ko-KR) then memberId, keep members with voteRecordsPath, probe published detail files, and use the first two results.",
+    appBaseUrl,
+    dataRepoBaseUrl,
+    manifestUrl,
+    calendarUrl,
+    single: {
+      ...primaryMember,
+      hash: singleHash,
+      url: new URL(singleHash, appBaseUrl).toString()
+    },
+    compare: {
+      primaryMember,
+      secondaryMember,
+      hash: compareHash,
+      url: new URL(compareHash, appBaseUrl).toString()
+    }
+  };
+}
+
+export async function resolveProductionUiRoutes({
+  appBaseUrl = DEFAULT_APP_BASE_URL,
+  dataRepoBaseUrl = DEFAULT_DATA_REPO_BASE_URL,
+  fetchImpl = globalThis.fetch
+} = {}) {
+  const normalizedAppBaseUrl = normalizeBaseUrl(appBaseUrl);
+  const normalizedDataRepoBaseUrl = normalizeBaseUrl(dataRepoBaseUrl);
+  const manifestUrl = new URL("manifests/latest.json", normalizedDataRepoBaseUrl).toString();
+  const manifest = await fetchJson(fetchImpl, manifestUrl);
+  const calendarPath = manifest?.exports?.memberActivityCalendar?.path ?? "exports/member_activity_calendar.json";
+  const calendarUrl = new URL(calendarPath, normalizedDataRepoBaseUrl).toString();
+  const calendar = await fetchJson(fetchImpl, calendarUrl);
+  const selectedMembers = await pickVerificationMembers(calendar?.assembly?.members ?? [], {
+    dataRepoBaseUrl: normalizedDataRepoBaseUrl,
+    fetchImpl
+  });
+
+  return buildVerificationRoutes({
+    appBaseUrl: normalizedAppBaseUrl,
+    dataRepoBaseUrl: normalizedDataRepoBaseUrl,
+    manifestUrl,
+    calendarUrl,
+    snapshotId: manifest?.snapshotId ?? null,
+    updatedAt: manifest?.updatedAt ?? null,
+    selectedMembers
+  });
+}
+
+const cliEntryUrl = process.argv[1] ? pathToFileURL(resolvePath(process.argv[1])).href : null;
+
+if (cliEntryUrl && import.meta.url === cliEntryUrl) {
+  const output = await resolveProductionUiRoutes();
+  console.log(JSON.stringify(output, null, 2));
+}

--- a/tests/ingest/resolve-production-ui-routes.test.ts
+++ b/tests/ingest/resolve-production-ui-routes.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  compareVerificationMembers,
+  pickVerificationMembers,
+  resolveProductionUiRoutes
+} from "../../scripts/resolve-production-ui-routes.mjs";
+
+describe("compareVerificationMembers", () => {
+  it("sorts by name first and memberId second", () => {
+    const members = [
+      { memberId: "M003", name: "Kim" },
+      { memberId: "M001", name: "Kim" },
+      { memberId: "M002", name: "Ahn" }
+    ];
+
+    expect(members.sort(compareVerificationMembers)).toEqual([
+      { memberId: "M002", name: "Ahn" },
+      { memberId: "M001", name: "Kim" },
+      { memberId: "M003", name: "Kim" }
+    ]);
+  });
+});
+
+describe("pickVerificationMembers", () => {
+  it("skips candidates whose published detail file does not resolve", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith("/exports/member_activity_calendar_members/M001.json")) {
+        return new Response(null, { status: 404 });
+      }
+
+      return new Response(null, { status: 200 });
+    });
+
+    const selectedMembers = await pickVerificationMembers(
+      [
+        {
+          memberId: "M002",
+          name: "Bora",
+          party: "Alpha",
+          voteRecordsPath: "exports/member_activity_calendar_members/M002.json"
+        },
+        {
+          memberId: "M001",
+          name: "Ara",
+          party: "Alpha",
+          voteRecordsPath: "exports/member_activity_calendar_members/M001.json"
+        },
+        {
+          memberId: "M003",
+          name: "Duri",
+          party: "Beta",
+          voteRecordsPath: "exports/member_activity_calendar_members/M003.json"
+        }
+      ],
+      {
+        dataRepoBaseUrl: "https://data.example.test/",
+        fetchImpl
+      }
+    );
+
+    expect(selectedMembers.map((member) => member.memberId)).toEqual(["M002", "M003"]);
+  });
+});
+
+describe("resolveProductionUiRoutes", () => {
+  it("builds live verification URLs from the published manifest and calendar export", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === "https://data.example.test/manifests/latest.json") {
+        return new Response(
+          JSON.stringify({
+            snapshotId: "snapshot-123",
+            updatedAt: "2026-03-27T05:43:15.528Z",
+            exports: {
+              memberActivityCalendar: {
+                path: "exports/member_activity_calendar.json"
+              }
+            }
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          }
+        );
+      }
+
+      if (url === "https://data.example.test/exports/member_activity_calendar.json") {
+        return new Response(
+          JSON.stringify({
+            assembly: {
+              members: [
+                {
+                  memberId: "M002",
+                  name: "Bora",
+                  party: "Alpha",
+                  voteRecordsPath: "exports/member_activity_calendar_members/M002.json"
+                },
+                {
+                  memberId: "M001",
+                  name: "Ara",
+                  party: "Alpha",
+                  voteRecordsPath: "exports/member_activity_calendar_members/M001.json"
+                },
+                {
+                  memberId: "M003",
+                  name: "Duri",
+                  party: "Beta",
+                  voteRecordsPath: "exports/member_activity_calendar_members/M003.json"
+                }
+              ]
+            }
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          }
+        );
+      }
+
+      if (url.endsWith("/exports/member_activity_calendar_members/M001.json")) {
+        return new Response(null, { status: 404 });
+      }
+
+      return new Response(null, { status: 200 });
+    });
+
+    const routes = await resolveProductionUiRoutes({
+      appBaseUrl: "https://app.example.test/lawmaker-monitor/",
+      dataRepoBaseUrl: "https://data.example.test/",
+      fetchImpl
+    });
+
+    expect(routes.snapshotId).toBe("snapshot-123");
+    expect(routes.single).toMatchObject({
+      memberId: "M002",
+      name: "Bora",
+      hash: "#calendar?member=M002",
+      url: "https://app.example.test/lawmaker-monitor/#calendar?member=M002"
+    });
+    expect(routes.compare.primaryMember).toMatchObject({
+      memberId: "M002",
+      name: "Bora"
+    });
+    expect(routes.compare.secondaryMember).toMatchObject({
+      memberId: "M003",
+      name: "Duri"
+    });
+    expect(routes.compare.url).toBe(
+      "https://app.example.test/lawmaker-monitor/#calendar?member=M002&compare=M003&view=compare"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a repo-level helper that resolves live single and compare calendar URLs from the published manifest
- cover the helper with targeted tests and expose it through `npm run resolve:production-ui-routes`
- document the production verification evidence fields and a shared comment template

## Validation
- `npm test -- tests/ingest/resolve-production-ui-routes.test.ts`
- `npm run resolve:production-ui-routes`