### PR TITLE
[codex] Add PR validation workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,37 @@
+name: pr-checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node, install dependencies, and build shared workspaces
+        uses: ./.github/actions/setup-node-workspaces
+        with:
+          build-target: schemas-and-ingest
+
+      - name: Build web app
+        run: npm run build --workspace @lawmaker-monitor/web
+        env:
+          VITE_DATA_REPO_BASE_URL: http://127.0.0.1:4174
+
+      - name: Run test suite
+        run: npm test
+
+      - name: Run typecheck
+        run: npm run typecheck

--- a/plans/2026-03-28-pr-checks-review-flow-decision.md
+++ b/plans/2026-03-28-pr-checks-review-flow-decision.md
@@ -1,0 +1,38 @@
+# 2026-03-28 PR Checks Review Flow Decision
+
+## 배경
+
+- draft PR `#8`을 열었지만 GitHub branch checks가 하나도 보고되지 않았다.
+- 현재 repository workflow는 `main` push와 data/deploy automation에는 반응하지만, `pull_request` 기준의 기본 검증 경로가 없다.
+- 이 상태는 UI나 라우팅 변경이 review 전에 자동 근거 없이 머무는 구조라서 review flow evidence 결함으로 본다.
+
+## 결정
+
+- `main` 대상 pull request마다 동작하는 `pr-checks` workflow를 추가한다.
+- scope는 최소 검증으로 제한한다:
+  - shared workspace build (`schemas`, `ingest`)
+  - web build
+  - `npm test`
+  - `npm run typecheck`
+- 기존 deploy/data workflow는 건드리지 않고 별도 workflow 파일로 추가한다.
+
+## 이유
+
+- 이미 있는 reusable setup action을 그대로 재사용할 수 있다.
+- product-surface PR에 최소한의 자동 근거를 붙여 review ergonomics를 개선한다.
+- 배포 workflow와 분리하면 운영 side effect 없이 review-only evidence를 보강할 수 있다.
+
+## 검증
+
+- representative clean worktree에서 아래 명령을 통과시켰다.
+  - `npm ci`
+  - `npm run build --workspace @lawmaker-monitor/schemas`
+  - `npm run build --workspace @lawmaker-monitor/ingest`
+  - `npm run build --workspace @lawmaker-monitor/web`
+  - `npm test`
+  - `npm run typecheck`
+
+## 후속
+
+- Paperclip live context가 복구되면, review flow defect 성격으로 이 변경을 owning issue에 연결한다.
+- PR checks가 붙기 시작하면 이후 product PR에서는 local-only evidence 의존도를 낮춘다.


### PR DESCRIPTION
## Summary
- add a dedicated `pull_request` validation workflow so product and data PRs get automatic evidence before review
- reuse the existing workspace setup action and run shared workspace builds, web build, tests, and typecheck on every PR to `main`
- document the review-flow decision and validation basis in a project-root decision record

## Why

Recent PRs could be opened and reviewed without any reported branch checks. That leaves UI and routing changes without automatic evidence in the review loop. This change restores a minimum review-flow safety net without changing deploy or data-publish automation.

## Validation
- `npm ci`
- `npm run build --workspace @lawmaker-monitor/schemas`
- `npm run build --workspace @lawmaker-monitor/ingest`
- `npm run build --workspace @lawmaker-monitor/web`
- `npm test`
- `npm run typecheck`
