### PR TITLE
Add reproducible constituency boundary publication pipeline

### DIFF
--- a/.github/workflows/build-data.yml
+++ b/.github/workflows/build-data.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           build-target: schemas-and-ingest
 
+      - name: Build constituency boundary source artifact
+        run: npm run build:constituency-boundaries --workspace @lawmaker-monitor/ingest
+
       - name: Resolve raw artifact source for manual build
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.raw_source != 'fixtures'
         id: resolve-manual-run

--- a/docs/references/constituency-boundary-pipeline.md
+++ b/docs/references/constituency-boundary-pipeline.md
@@ -1,0 +1,69 @@
+# Constituency Boundary Pipeline
+
+This document describes the reproducible handoff for constituency-level map data used by the district visualization workstream.
+
+## Output
+
+- `artifacts/constituency-boundaries/current/constituency_boundaries.geojson`
+- `artifacts/constituency-boundaries/current/source_manifest.json`
+- `artifacts/build/exports/constituency_boundaries/index.json`
+- `artifacts/build/exports/constituency_boundaries/provinces/<provinceShortName>.topo.json`
+
+The GeoJSON file is a feature collection of current National Assembly constituency boundaries with:
+
+- official law district names
+- member-facing district aliases for matching the Assembly `district` field
+- resolved `sigungu` and `emd` codes and names
+- dissolved district geometries
+
+## Official Sources
+
+1. Public law source
+- Page: `https://www.law.go.kr/lsBylInfoPLinkR.do?lsiSeq=284577&lsNm=%EA%B3%B5%EC%A7%81%EC%84%A0%EA%B1%B0%EB%B2%95&bylNo=0001&bylBrNo=00&bylCls=BE&bylEfYd=20260319&bylEfYdYn=Y`
+- Download endpoint: `https://www.law.go.kr/LSW/lsBylTextDownLoad.do`
+- Request body: `bylSeq=18012299&title=%5B%EB%B3%84%ED%91%9C+1%5D+%EA%B5%AD%ED%9A%8C%EC%9D%98%EC%9B%90%EC%A7%80%EC%97%AD%EC%84%A0%EA%B1%B0%EA%B5%AC%EA%B5%AC%EC%97%AD%ED%91%9C+%28%EC%A7%80%EC%97%AD%EA%B5%AC+%3A+254%29&mode=0`
+
+2. Official SGIS admin boundary bundle
+- data page: `https://www.data.go.kr/data/15129688/fileData.do`
+- direct download: `https://www.data.go.kr/cmm/cmm/fileDownload.do?atchFileId=FILE_000000003601705&fileDetailSn=1&insertDataPrcus=N`
+- consumed layers:
+  - `bnd_sigungu_00_2025_2Q.*`
+  - `bnd_dong_00_2025_2Q.*`
+
+## Build Command
+
+```bash
+npm run build --workspace @lawmaker-monitor/schemas
+npm run build --workspace @lawmaker-monitor/ingest
+npm run build:constituency-boundaries
+npm run build:data --workspace @lawmaker-monitor/ingest
+```
+
+Optional overrides:
+
+```bash
+OUTPUT_DIR=artifacts/constituency-boundaries/current \
+FETCH_TIMEOUT_MS=180000 \
+npm run build:constituency-boundaries
+
+CONSTITUENCY_BOUNDARIES_DIR=artifacts/constituency-boundaries/current \
+OUTPUT_DIR=artifacts/build \
+npm run build:data --workspace @lawmaker-monitor/ingest
+```
+
+## Mapping Rules
+
+- The law source is authoritative for district-to-admin-unit membership.
+- The SGIS `sigungu` shapefile provides the official `sigungu` code-to-name table used for administrative-dong attribution.
+- The SGIS `dong` shapefile provides official administrative-dong boundaries and `ADM_CD` codes.
+- Administrative dongs are assigned to `sigungu` by the first five digits of `ADM_CD`, then matched against law text with conservative fallback variants for duplicated or ordinal `제` markers.
+- Member district aliases are emitted with province short forms such as `서울`, `부산`, `경기`, `전북`, and `세종`.
+
+## Current Delivery Scope
+
+- `build:constituency-boundaries` is the reproducible source artifact step.
+- `build-data` republishes that artifact as a shared runtime contract through:
+  - `manifests/latest.json -> exports.constituencyBoundariesIndex`
+  - `exports/constituency_boundaries/index.json`
+  - `exports/constituency_boundaries/provinces/<provinceShortName>.topo.json`
+- Province shards intentionally preserve the full district geometry plus matching metadata while staying under the existing published JSON size guard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1674,7 +1674,6 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1940,6 +1939,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/array-source": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/array-source/-/array-source-0.0.4.tgz",
+      "integrity": "sha512-frNdc+zBn80vipY+GdcJkLEbMWj3xmzArYApmUGxoiV8uAu/ygcs9icPdsGdA26h0MkHUMW6EN2piIvVx+M5Mw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2160,6 +2165,12 @@
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2558,6 +2569,15 @@
         }
       }
     },
+    "node_modules/file-source": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-source/-/file-source-0.6.1.tgz",
+      "integrity": "sha512-1R1KneL7eTXmXfKxC10V/9NeGOdbsAXJ+lQ//fvvcHUgtaZcZDWNJNblxAoVOyV1cj45pOtUrR3vZTBwqcW8XA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-source": "0.3"
+      }
+    },
     "node_modules/find-replace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
@@ -2920,6 +2940,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/path-source": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/path-source/-/path-source-0.1.3.tgz",
+      "integrity": "sha512-dWRHm5mIw5kw0cs3QZLNmpUWty48f5+5v9nWD2dw3Y0Hf+s01Ag8iJEWV0Sm0kocE8kK27DrIowha03e1YR+Qw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "array-source": "0.0",
+        "file-source": "0.6"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3256,7 +3286,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -3291,12 +3320,36 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shapefile": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/shapefile/-/shapefile-0.6.6.tgz",
+      "integrity": "sha512-rLGSWeK2ufzCVx05wYd+xrWnOOdSV7xNUW5/XFgx3Bc02hBkpMlrd2F1dDII7/jhWzv0MSyBFh5uJIy9hLdfuw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "array-source": "0.0",
+        "commander": "2",
+        "path-source": "0.1",
+        "slice-source": "0.4",
+        "stream-source": "0.3",
+        "text-encoding": "^0.6.4"
+      },
+      "bin": {
+        "dbf2json": "bin/dbf2json",
+        "shp2json": "bin/shp2json"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/slice-source": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
+      "integrity": "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3321,6 +3374,12 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stream-source": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/stream-source/-/stream-source-0.3.5.tgz",
+      "integrity": "sha512-ZuEDP9sgjiAwUVoDModftG0JtYiLUV8K4ljYD1VyUMRWtbVf92474o4kuuul43iZ8t/hRuiDAx1dIJSvirrK/g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -3407,6 +3466,13 @@
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "node_modules/text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha512-hJnc6Qg3dWoOMkqP53F0dzRIgtmsAge09kxUIqGrEUS4qr5rWLckGYaQAVr+opBrIMRErGgy6f5aPnyPpyGRfg==",
+      "deprecated": "no longer maintained",
+      "license": "Unlicense"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -3495,6 +3561,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -3554,7 +3646,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3868,6 +3959,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/wkx": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/wordwrapjs": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
@@ -3938,7 +4038,28 @@
       "dependencies": {
         "@lawmaker-monitor/schemas": "0.1.0",
         "fast-xml-parser": "^5.2.5",
-        "playwright": "^1.54.2"
+        "iconv-lite": "^0.7.0",
+        "playwright": "^1.54.2",
+        "shapefile": "^0.6.6",
+        "topojson-client": "^3.1.0",
+        "topojson-server": "^3.0.1",
+        "wkx": "^0.5.0"
+      }
+    },
+    "packages/ingest/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "packages/schemas": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspace @lawmaker-monitor/schemas && npm run build --workspace @lawmaker-monitor/ingest && npm run build --workspace @lawmaker-monitor/web",
+    "build:constituency-boundaries": "npm run build:constituency-boundaries --workspace @lawmaker-monitor/ingest",
     "build:data": "npm run build:data --workspace @lawmaker-monitor/ingest",
     "dev:web": "npm run dev --workspace @lawmaker-monitor/web",
     "ingest:live": "npm run ingest:live --workspace @lawmaker-monitor/ingest",

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build:constituency-boundaries": "node ./dist/scripts/build-constituency-boundaries.js",
     "build:data": "node ./dist/scripts/build-data.js",
     "ingest:live": "node ./dist/scripts/ingest-live.js",
     "mirror:documents": "node ./dist/scripts/mirror-documents.js",
@@ -20,6 +21,11 @@
   "dependencies": {
     "@lawmaker-monitor/schemas": "0.1.0",
     "fast-xml-parser": "^5.2.5",
-    "playwright": "^1.54.2"
+    "iconv-lite": "^0.7.0",
+    "playwright": "^1.54.2",
+    "shapefile": "^0.6.6",
+    "topojson-client": "^3.1.0",
+    "topojson-server": "^3.0.1",
+    "wkx": "^0.5.0"
   }
 }

--- a/packages/ingest/src/constituency-boundaries.ts
+++ b/packages/ingest/src/constituency-boundaries.ts
@@ -1,0 +1,1223 @@
+import { execFile as nodeExecFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import type {
+  ConstituencyBoundaryExport,
+  ConstituencyBoundaryFeature,
+  ConstituencyBoundarySource,
+  GeoJsonMultiPolygon,
+  GeoJsonPolygon
+} from "@lawmaker-monitor/schemas";
+
+import { sha256Buffer } from "./utils.js";
+
+const require = createRequire(import.meta.url);
+const iconv = require("iconv-lite") as {
+  decode(input: Buffer, encoding: string): string;
+};
+const wkx = require("wkx") as {
+  Geometry: {
+    parse(input: Buffer): {
+      toGeoJSON(): GeoJsonGeometry;
+    };
+  };
+};
+const shapefile = require("shapefile") as {
+  read(
+    shp: ArrayBuffer | Buffer,
+    dbf?: ArrayBuffer | Buffer,
+    options?: { encoding?: string }
+  ): Promise<GeoJsonFeatureCollection>;
+};
+const topojsonClient = require("topojson-client") as {
+  merge(topology: Topology, objects: TopologyGeometry[]): GeoJsonGeometry;
+};
+const topojsonServer = require("topojson-server") as {
+  topology(objects: Record<string, GeoJsonFeatureCollection>): Topology;
+};
+const execFile = promisify(nodeExecFile);
+
+type GeoJsonGeometry = GeoJsonPolygon | GeoJsonMultiPolygon;
+
+type GeoJsonFeature = {
+  type: "Feature";
+  id?: string;
+  properties: Record<string, unknown>;
+  geometry: GeoJsonGeometry;
+};
+
+type GeoJsonFeatureCollection = {
+  type: "FeatureCollection";
+  features: GeoJsonFeature[];
+};
+
+type TopologyGeometry = {
+  type: string;
+  id?: string | number;
+  properties?: Record<string, unknown>;
+};
+
+type TopologyObject = {
+  type: "GeometryCollection";
+  geometries: TopologyGeometry[];
+};
+
+type Topology = {
+  type: "Topology";
+  objects: Record<string, TopologyObject>;
+};
+
+type ProvinceInfo = {
+  officialCode: string;
+  sgisCode: string;
+  fullName: string;
+  shortName: string;
+};
+
+export type ConstituencyLawRecord = {
+  provinceName: string;
+  provinceShortName: string;
+  lawDistrictName: string;
+  districtName: string;
+  areaText: string;
+};
+
+export type NgiiSigunguRecord = {
+  sigunguCode: string;
+  sigunguObjectCode: string | null;
+  sigunguName: string;
+};
+
+export type NgiiEmdRecord = {
+  emdCode: string;
+  emdName: string;
+  sigunguCode: string;
+  geometry: GeoJsonGeometry;
+};
+
+type IndexedEmdRecord = NgiiEmdRecord & {
+  provinceName: string;
+  provinceShortName: string;
+  officialSigunguCode: string;
+  sigunguName: string;
+};
+
+type DownloadedSource = {
+  content: Buffer;
+  retrievedAt: string;
+};
+
+type DownloadedTextSource = {
+  text: string;
+  source: ConstituencyBoundarySource;
+};
+
+type DownloadedBoundaryBundle = {
+  indexedEmdRecords: IndexedEmdRecord[];
+  sigunguSource: ConstituencyBoundarySource;
+  emdSource: ConstituencyBoundarySource;
+};
+
+type SigunguGeometryRecord = {
+  sigunguCode: string;
+  sigunguName: string;
+  geometry: GeoJsonGeometry;
+  bbox: [number, number, number, number];
+};
+
+type DongGeometryRecord = {
+  emdCode: string;
+  emdName: string;
+  geometry: GeoJsonGeometry;
+};
+
+export const CONSTITUENCY_LAW_PAGE_URL =
+  "https://www.law.go.kr/lsBylInfoPLinkR.do?lsiSeq=284577&lsNm=%EA%B3%B5%EC%A7%81%EC%84%A0%EA%B1%B0%EB%B2%95&bylNo=0001&bylBrNo=00&bylCls=BE&bylEfYd=20260319&bylEfYdYn=Y";
+export const CONSTITUENCY_LAW_DOWNLOAD_URL = "https://www.law.go.kr/LSW/lsBylTextDownLoad.do";
+export const CONSTITUENCY_LAW_DOWNLOAD_BODY = new URLSearchParams({
+  bylSeq: "18012299",
+  title: "[별표 1] 국회의원지역선거구구역표 (지역구 : 254)",
+  mode: "0"
+}).toString();
+export const CONSTITUENCY_LAW_EFFECTIVE_DATE = "2026-03-19";
+
+export const SGIS_BOUNDARY_DATA_PAGE_URL = "https://www.data.go.kr/data/15129688/fileData.do";
+export const SGIS_BOUNDARY_DOWNLOAD_URL =
+  "https://www.data.go.kr/cmm/cmm/fileDownload.do?atchFileId=FILE_000000003601705&fileDetailSn=1&insertDataPrcus=N";
+
+export const NGII_SIGUNGU_DATA_PAGE_URL = "https://www.data.go.kr/data/15123131/fileData.do";
+export const NGII_SIGUNGU_DOWNLOAD_URL =
+  "https://www.data.go.kr/cmm/cmm/fileDownload.do?atchFileId=FILE_000000002819519&fileDetailSn=1&insertDataPrcus=N";
+
+export const NGII_EMD_DATA_PAGE_URL = "https://www.data.go.kr/data/15123128/fileData.do";
+export const NGII_EMD_DOWNLOAD_URL =
+  "https://www.data.go.kr/cmm/cmm/fileDownload.do?atchFileId=FILE_000000002819529&fileDetailSn=1&insertDataPrcus=N";
+
+const DEFAULT_FETCH_TIMEOUT_MS = 120_000;
+
+const PROVINCES: ProvinceInfo[] = [
+  { officialCode: "11", sgisCode: "11", fullName: "서울특별시", shortName: "서울" },
+  { officialCode: "26", sgisCode: "21", fullName: "부산광역시", shortName: "부산" },
+  { officialCode: "27", sgisCode: "22", fullName: "대구광역시", shortName: "대구" },
+  { officialCode: "28", sgisCode: "23", fullName: "인천광역시", shortName: "인천" },
+  { officialCode: "29", sgisCode: "24", fullName: "광주광역시", shortName: "광주" },
+  { officialCode: "30", sgisCode: "25", fullName: "대전광역시", shortName: "대전" },
+  { officialCode: "31", sgisCode: "26", fullName: "울산광역시", shortName: "울산" },
+  { officialCode: "36", sgisCode: "29", fullName: "세종특별자치시", shortName: "세종" },
+  { officialCode: "41", sgisCode: "31", fullName: "경기도", shortName: "경기" },
+  { officialCode: "42", sgisCode: "32", fullName: "강원특별자치도", shortName: "강원" },
+  { officialCode: "43", sgisCode: "33", fullName: "충청북도", shortName: "충북" },
+  { officialCode: "44", sgisCode: "34", fullName: "충청남도", shortName: "충남" },
+  { officialCode: "45", sgisCode: "35", fullName: "전북특별자치도", shortName: "전북" },
+  { officialCode: "46", sgisCode: "36", fullName: "전라남도", shortName: "전남" },
+  { officialCode: "47", sgisCode: "37", fullName: "경상북도", shortName: "경북" },
+  { officialCode: "48", sgisCode: "38", fullName: "경상남도", shortName: "경남" },
+  { officialCode: "50", sgisCode: "39", fullName: "제주특별자치도", shortName: "제주" }
+];
+
+const provinceByOfficialCode = new Map(PROVINCES.map((item) => [item.officialCode, item] as const));
+const provinceBySgisCode = new Map(PROVINCES.map((item) => [item.sgisCode, item] as const));
+const provinceByFullName = new Map(PROVINCES.map((item) => [item.fullName, item] as const));
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeAdministrativeNameKey(value: string): string {
+  return normalizeWhitespace(value)
+    .replace(/\s+/g, "")
+    .replace(/[ㆍ?]/g, "·");
+}
+
+function normalizeLawCell(value: string): string {
+  return normalizeWhitespace(value).replace(/[ㆍ?]/g, "·");
+}
+
+function collapseDuplicateOrdinalMarker(value: string): string {
+  return value.replace(/제제(?=\d+(?:·\d+)*[동리읍면가])/g, "제");
+}
+
+function stripOrdinalMarker(value: string): string {
+  return value.replace(/제(?=\d+(?:·\d+)*[동리읍면가])/g, "");
+}
+
+function buildAdministrativeNameMatchKeys(value: string): string[] {
+  const exact = normalizeAdministrativeNameKey(value);
+  const collapsed = normalizeAdministrativeNameKey(collapseDuplicateOrdinalMarker(value));
+  const stripped = normalizeAdministrativeNameKey(stripOrdinalMarker(collapseDuplicateOrdinalMarker(value)));
+  return [...new Set([exact, collapsed, stripped])];
+}
+
+function buildCollapsedSubdivisionKey(value: string): string | null {
+  const digitCount = value.match(/\d/g)?.length ?? 0;
+  if (digitCount !== 1) {
+    return null;
+  }
+  return normalizeAdministrativeNameKey(value.replace(/\d+(?=[동리])/, ""));
+}
+
+function buildMemberDistrictLabel(province: ProvinceInfo, districtName: string): string {
+  const shortenedDistrictName = districtName
+    .replace(/특별자치시/g, "시")
+    .replace(/특별자치도/g, "도");
+  return `${province.shortName} ${shortenedDistrictName}`;
+}
+
+function buildDistrictAliases(province: ProvinceInfo, districtName: string): string[] {
+  const shortenedDistrictName = districtName
+    .replace(/특별자치시/g, "시")
+    .replace(/특별자치도/g, "도");
+  const aliases = new Set<string>([
+    districtName,
+    shortenedDistrictName,
+    `${province.fullName} ${districtName}`,
+    `${province.fullName}${districtName}`,
+    `${province.shortName} ${districtName}`,
+    `${province.shortName}${districtName}`,
+    `${province.shortName} ${shortenedDistrictName}`,
+    `${province.shortName}${shortenedDistrictName}`
+  ]);
+  return [...aliases].sort((left, right) => left.localeCompare(right, "ko"));
+}
+
+function parseLawLineCells(line: string): string[] {
+  const cells = [...line.matchAll(/│([^│]*)/g)].map((match) => normalizeLawCell(match[1] ?? ""));
+  if (cells.at(-1) === "") {
+    return cells.slice(0, -1);
+  }
+  return cells;
+}
+
+function joinLawFragments(fragments: string[]): string {
+  return fragments.reduce((result, fragment) => {
+    if (!result) {
+      return fragment;
+    }
+    if (/[,(]$/.test(result) || /^[,)]/.test(fragment)) {
+      return `${result}${fragment}`;
+    }
+    return `${result} ${fragment}`;
+  }, "");
+}
+
+export function parseConstituencyLawText(text: string): ConstituencyLawRecord[] {
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  const records: ConstituencyLawRecord[] = [];
+  let currentProvince: ProvinceInfo | null = null;
+  let currentDistrictName = "";
+  let currentAreaFragments: string[] = [];
+
+  const pushCurrent = () => {
+    if (!currentProvince || !currentDistrictName) {
+      currentDistrictName = "";
+      currentAreaFragments = [];
+      return;
+    }
+
+    records.push({
+      provinceName: currentProvince.fullName,
+      provinceShortName: currentProvince.shortName,
+      lawDistrictName: currentDistrictName,
+      districtName: currentDistrictName.replace(/선거구$/, ""),
+      areaText: joinLawFragments(currentAreaFragments)
+    });
+    currentDistrictName = "";
+    currentAreaFragments = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!line.startsWith("│")) {
+      continue;
+    }
+
+    const cells = parseLawLineCells(line);
+    if (cells.length === 0) {
+      continue;
+    }
+
+    if (cells.length === 1) {
+      const heading = cells[0] ?? "";
+      const provinceName = heading.split("(")[0]?.trim() ?? "";
+      const province = provinceByFullName.get(provinceName);
+      if (province && heading.includes("지역구")) {
+        pushCurrent();
+        currentProvince = province;
+      }
+      continue;
+    }
+
+    const left = cells[0] ?? "";
+    const right = cells[1] ?? "";
+    if (normalizeAdministrativeNameKey(left) === "선거구명") {
+      continue;
+    }
+
+    if (left === "선거구" && currentDistrictName) {
+      currentDistrictName = `${currentDistrictName}${left}`;
+      if (right) {
+        currentAreaFragments.push(right);
+      }
+      continue;
+    }
+
+    if (currentDistrictName && !currentDistrictName.endsWith("선거구") && left.endsWith("선거구")) {
+      currentDistrictName = `${currentDistrictName}${left}`;
+      if (right) {
+        currentAreaFragments.push(right);
+      }
+      continue;
+    }
+
+    if (left) {
+      pushCurrent();
+      if (!currentProvince) {
+        throw new Error(`Could not resolve province header before district row "${left}".`);
+      }
+      currentDistrictName = left;
+      currentAreaFragments = right ? [right] : [];
+      continue;
+    }
+
+    if (currentDistrictName && right) {
+      currentAreaFragments.push(right);
+    }
+  }
+
+  pushCurrent();
+
+  if (records.length === 0) {
+    throw new Error("Failed to parse any constituency rows from the official law text.");
+  }
+
+  return records;
+}
+
+function listOuterRings(geometry: GeoJsonGeometry): Array<Array<[number, number]>> {
+  if (geometry.type === "Polygon") {
+    const outer = geometry.coordinates[0] ?? [];
+    return [outer];
+  }
+
+  return geometry.coordinates
+    .map((polygon) => polygon[0] ?? [])
+    .filter((ring): ring is Array<[number, number]> => ring.length > 0);
+}
+
+function computeRingBBox(ring: Array<[number, number]>): [number, number, number, number] {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const [x, y] of ring) {
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+
+  return [minX, minY, maxX, maxY];
+}
+
+function computeGeometryBBox(geometry: GeoJsonGeometry): [number, number, number, number] {
+  const rings = listOuterRings(geometry);
+  const initial: [number, number, number, number] = [
+    Number.POSITIVE_INFINITY,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    Number.NEGATIVE_INFINITY
+  ];
+
+  return rings.reduce<[number, number, number, number]>((bbox, ring) => {
+    const [minX, minY, maxX, maxY] = computeRingBBox(ring);
+    return [
+      Math.min(bbox[0], minX),
+      Math.min(bbox[1], minY),
+      Math.max(bbox[2], maxX),
+      Math.max(bbox[3], maxY)
+    ];
+  }, initial);
+}
+
+function buildProbePoints(geometry: GeoJsonGeometry): Array<[number, number]> {
+  const rings = listOuterRings(geometry);
+  const ringArea = (ring: Array<[number, number]>): number => {
+    const [minX, minY, maxX, maxY] = computeRingBBox(ring);
+    return Math.max(0, maxX - minX) * Math.max(0, maxY - minY);
+  };
+  const largestRing =
+    rings
+      .slice()
+      .sort((left, right) => ringArea(right) - ringArea(left))[0] ??
+    [];
+  const bbox = computeGeometryBBox(geometry);
+  const bboxCenter: [number, number] = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2];
+  const coordinateAverage: [number, number] =
+    largestRing.length > 0
+      ? [
+          largestRing.reduce((sum, point) => sum + point[0], 0) / largestRing.length,
+          largestRing.reduce((sum, point) => sum + point[1], 0) / largestRing.length
+        ]
+      : bboxCenter;
+  const firstPoint = largestRing[0] ?? bboxCenter;
+  const edgeMidpoints = largestRing.slice(0, 12).map((point, index) => {
+    const next = largestRing[(index + 1) % largestRing.length] ?? point;
+    return [(point[0] + next[0]) / 2, (point[1] + next[1]) / 2] as [number, number];
+  });
+
+  return [bboxCenter, coordinateAverage, firstPoint, ...edgeMidpoints];
+}
+
+function bboxContainsPoint(
+  bbox: [number, number, number, number],
+  point: [number, number]
+): boolean {
+  return point[0] >= bbox[0] && point[0] <= bbox[2] && point[1] >= bbox[1] && point[1] <= bbox[3];
+}
+
+function pointInRing(point: [number, number], ring: Array<[number, number]>): boolean {
+  let inside = false;
+
+  for (let index = 0, previous = ring.length - 1; index < ring.length; previous = index, index += 1) {
+    const [x1, y1] = ring[index] ?? [0, 0];
+    const [x2, y2] = ring[previous] ?? [0, 0];
+    const intersects =
+      (y1 > point[1]) !== (y2 > point[1]) &&
+      point[0] < ((x2 - x1) * (point[1] - y1)) / ((y2 - y1) || Number.EPSILON) + x1;
+    if (intersects) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}
+
+function pointInGeometry(point: [number, number], geometry: GeoJsonGeometry): boolean {
+  if (geometry.type === "Polygon") {
+    const [outerRing, ...holes] = geometry.coordinates;
+    if (!outerRing || !pointInRing(point, outerRing)) {
+      return false;
+    }
+    return !holes.some((ring) => pointInRing(point, ring));
+  }
+
+  return geometry.coordinates.some((polygon) => {
+    const [outerRing, ...holes] = polygon;
+    if (!outerRing || !pointInRing(point, outerRing)) {
+      return false;
+    }
+    return !holes.some((ring) => pointInRing(point, ring));
+  });
+}
+
+function findProvinceBySigunguCode(sigunguCode: string): ProvinceInfo {
+  const province = provinceBySgisCode.get(sigunguCode.slice(0, 2));
+  if (!province) {
+    throw new Error(`Unknown province prefix for sigungu ${sigunguCode}.`);
+  }
+  return province;
+}
+
+async function extractSgisShapefile(args: {
+  zipBuffer: Buffer;
+  basename: string;
+}): Promise<{
+  shp: Buffer;
+  dbf: Buffer;
+  cpg: string;
+}> {
+  const tempRoot = await mkdtemp(join(tmpdir(), "sgis-boundary-"));
+  const zipPath = join(tempRoot, "sgis-boundaries.zip");
+
+  try {
+    await writeFile(zipPath, args.zipBuffer);
+    await execFile("unzip", ["-j", zipPath, `*${args.basename}.*`, "-d", tempRoot]);
+
+    const [shp, dbf, cpg] = await Promise.all([
+      readFile(join(tempRoot, `${args.basename}.shp`)),
+      readFile(join(tempRoot, `${args.basename}.dbf`)),
+      readFile(join(tempRoot, `${args.basename}.cpg`), "utf8")
+    ]);
+
+    return {
+      shp,
+      dbf,
+      cpg: cpg.trim()
+    };
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function readSgisFeatureCollection(args: {
+  zipBuffer: Buffer;
+  basename: string;
+}): Promise<GeoJsonFeatureCollection> {
+  const { shp, dbf, cpg } = await extractSgisShapefile(args);
+  return shapefile.read(shp, dbf, {
+    encoding: cpg || "utf-8"
+  });
+}
+
+function parseSgisSigunguRecords(collection: GeoJsonFeatureCollection): SigunguGeometryRecord[] {
+  return collection.features.map((feature) => {
+    const sigunguCode = String(feature.properties.SIGUNGU_CD ?? "").trim();
+    const sigunguName = String(feature.properties.SIGUNGU_NM ?? "").trim();
+    if (!sigunguCode || !sigunguName) {
+      throw new Error("SGIS sigungu shapefile is missing SIGUNGU_CD or SIGUNGU_NM.");
+    }
+    return {
+      sigunguCode,
+      sigunguName,
+      geometry: feature.geometry,
+      bbox: computeGeometryBBox(feature.geometry)
+    };
+  });
+}
+
+function parseSgisDongRecords(collection: GeoJsonFeatureCollection): DongGeometryRecord[] {
+  return collection.features.map((feature) => {
+    const emdCode = String(feature.properties.ADM_CD ?? "").trim();
+    const emdName = String(feature.properties.ADM_NM ?? "").trim();
+    if (!emdCode || !emdName) {
+      throw new Error("SGIS dong shapefile is missing ADM_CD or ADM_NM.");
+    }
+    return {
+      emdCode,
+      emdName,
+      geometry: feature.geometry
+    };
+  });
+}
+
+function assignDongToSigungu(args: {
+  dong: DongGeometryRecord;
+  sigunguRecords: SigunguGeometryRecord[];
+}): SigunguGeometryRecord {
+  const probePoints = buildProbePoints(args.dong.geometry);
+
+  for (const point of probePoints) {
+    const bboxCandidates = args.sigunguRecords.filter((record) => bboxContainsPoint(record.bbox, point));
+    const matches = bboxCandidates.filter((record) => pointInGeometry(point, record.geometry));
+    if (matches.length === 1) {
+      const match = matches[0];
+      if (match) {
+        return match;
+      }
+    }
+  }
+
+  throw new Error(`Could not assign administrative dong ${args.dong.emdCode} to a sigungu geometry.`);
+}
+
+async function loadSgisBoundaryBundle(args: {
+  download: DownloadedSource;
+}): Promise<DownloadedBoundaryBundle> {
+  const [sigunguCollection, dongCollection] = await Promise.all([
+    readSgisFeatureCollection({
+      zipBuffer: args.download.content,
+      basename: "bnd_sigungu_00_2025_2Q"
+    }),
+    readSgisFeatureCollection({
+      zipBuffer: args.download.content,
+      basename: "bnd_dong_00_2025_2Q"
+    })
+  ]);
+
+  const sigunguSource = buildSource({
+    sourceId: "sgis-bnd-sigungu-2025-2q",
+    title: "SGIS 2025 Q2 sigungu boundary shapefile",
+    sourcePageUrl: SGIS_BOUNDARY_DATA_PAGE_URL,
+    downloadUrl: SGIS_BOUNDARY_DOWNLOAD_URL,
+    requestMethod: "GET",
+    encoding: "utf-8",
+    download: args.download
+  });
+  const dongSource = buildSource({
+    sourceId: "sgis-bnd-dong-2025-2q",
+    title: "SGIS 2025 Q2 administrative dong boundary shapefile",
+    sourcePageUrl: SGIS_BOUNDARY_DATA_PAGE_URL,
+    downloadUrl: SGIS_BOUNDARY_DOWNLOAD_URL,
+    requestMethod: "GET",
+    encoding: "utf-8",
+    download: args.download
+  });
+
+  const sigunguRecords = parseSgisSigunguRecords(sigunguCollection).filter((record) =>
+    provinceBySgisCode.has(record.sigunguCode.slice(0, 2))
+  );
+  const dongRecords = parseSgisDongRecords(dongCollection);
+  const sigunguByCode = new Map(sigunguRecords.map((record) => [record.sigunguCode, record] as const));
+  const indexedEmdRecords: IndexedEmdRecord[] = [];
+
+  for (const dong of dongRecords) {
+    const sigunguCode = dong.emdCode.slice(0, 5);
+    const sigungu = sigunguByCode.get(sigunguCode);
+    if (!sigungu) {
+      throw new Error(`Missing SGIS sigungu lookup for administrative dong ${dong.emdCode}.`);
+    }
+
+    const province = findProvinceBySigunguCode(sigungu.sigunguCode);
+    indexedEmdRecords.push({
+      emdCode: dong.emdCode,
+      emdName: dong.emdName,
+      sigunguCode: sigungu.sigunguCode,
+      officialSigunguCode: sigungu.sigunguCode,
+      sigunguName: sigungu.sigunguName,
+      provinceName: province.fullName,
+      provinceShortName: province.shortName,
+      geometry: dong.geometry
+    });
+  }
+
+  if (indexedEmdRecords.length === 0) {
+    throw new Error("Failed to assign any SGIS administrative dong features to South Korea sigungu shapes.");
+  }
+
+  return {
+    indexedEmdRecords,
+    sigunguSource: {
+      ...sigunguSource,
+      rowCount: sigunguRecords.length
+    },
+    emdSource: {
+      ...dongSource,
+      rowCount: indexedEmdRecords.length
+    }
+  };
+}
+
+function parseCsvRows(text: string): string[][] {
+  return text
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split(","));
+}
+
+export function parseNgiiSigunguCsv(text: string): NgiiSigunguRecord[] {
+  const rows = parseCsvRows(text);
+  const records: NgiiSigunguRecord[] = [];
+
+  for (const row of rows.slice(1)) {
+    const sigunguCode = row[1]?.trim() ?? "";
+    const sigunguObjectCode = row[3]?.trim() || null;
+    const sigunguName = row[2]?.trim() ?? "";
+    if (!sigunguCode || !sigunguName) {
+      continue;
+    }
+    records.push({
+      sigunguCode,
+      sigunguObjectCode,
+      sigunguName
+    });
+  }
+
+  if (records.length === 0) {
+    throw new Error("Failed to parse any sigungu rows from the NGII CSV.");
+  }
+
+  return records;
+}
+
+function parseWkbHexGeometry(hex: string): GeoJsonGeometry {
+  const geometry = wkx.Geometry.parse(Buffer.from(hex, "hex")).toGeoJSON() as {
+    type?: string;
+  } & Partial<GeoJsonGeometry>;
+  if (geometry.type !== "Polygon" && geometry.type !== "MultiPolygon") {
+    throw new Error(`Unsupported geometry type "${geometry.type}" in NGII 읍면동 data.`);
+  }
+  return geometry as GeoJsonGeometry;
+}
+
+export function parseNgiiEmdCsv(text: string): NgiiEmdRecord[] {
+  const rows = parseCsvRows(text);
+  const records: NgiiEmdRecord[] = [];
+
+  for (const row of rows.slice(1)) {
+    const emdCode = row[1]?.trim() ?? "";
+    const emdName = row[2]?.trim() ?? "";
+    const sigunguCode = row[3]?.trim() ?? "";
+    const geometryHex = row.slice(5).join(",").trim();
+    if (!emdCode || !emdName || !sigunguCode || !geometryHex) {
+      continue;
+    }
+    records.push({
+      emdCode,
+      emdName,
+      sigunguCode,
+      geometry: parseWkbHexGeometry(geometryHex)
+    });
+  }
+
+  if (records.length === 0) {
+    throw new Error("Failed to parse any 읍면동 rows from the NGII CSV.");
+  }
+
+  return records;
+}
+
+function buildIndexedEmdRecords(args: {
+  sigunguRecords: NgiiSigunguRecord[];
+  emdRecords: NgiiEmdRecord[];
+}): IndexedEmdRecord[] {
+  const sigunguByAnyCode = new Map<string, NgiiSigunguRecord>();
+  for (const record of args.sigunguRecords) {
+    sigunguByAnyCode.set(record.sigunguCode, record);
+    if (record.sigunguObjectCode) {
+      sigunguByAnyCode.set(record.sigunguObjectCode, record);
+    }
+  }
+
+  return args.emdRecords.map((record) => {
+    const province = provinceByOfficialCode.get(record.emdCode.slice(0, 2));
+    const sigungu = sigunguByAnyCode.get(record.sigunguCode);
+    if (!province) {
+      throw new Error(`Unknown province code "${record.emdCode.slice(0, 2)}" for ${record.emdCode}.`);
+    }
+    if (!sigungu) {
+      throw new Error(`Missing sigungu lookup for 읍면동 ${record.emdCode}.`);
+    }
+    return {
+      ...record,
+      provinceName: province.fullName,
+      provinceShortName: province.shortName,
+      officialSigunguCode: sigungu.sigunguCode,
+      sigunguName: sigungu.sigunguName
+    };
+  });
+}
+
+function buildSigunguIndex(records: IndexedEmdRecord[]): Map<string, IndexedEmdRecord[]> {
+  const index = new Map<string, IndexedEmdRecord[]>();
+
+  for (const record of records) {
+    const key = `${record.provinceShortName}|${normalizeAdministrativeNameKey(record.sigunguName)}`;
+    const items = index.get(key) ?? [];
+    items.push(record);
+    index.set(key, items);
+  }
+
+  return index;
+}
+
+function resolveSigunguRecords(args: {
+  provinceShortName: string;
+  sigunguName: string;
+  sigunguIndex: Map<string, IndexedEmdRecord[]>;
+}): IndexedEmdRecord[] {
+  const key = `${args.provinceShortName}|${normalizeAdministrativeNameKey(args.sigunguName)}`;
+  const records = args.sigunguIndex.get(key);
+  if (!records || records.length === 0) {
+    throw new Error(
+      `Could not resolve sigungu "${args.sigunguName}" in province "${args.provinceShortName}".`
+    );
+  }
+  return records;
+}
+
+function resolveEmdRecord(args: {
+  provinceShortName: string;
+  sigunguName: string;
+  emdName: string;
+  sigunguIndex: Map<string, IndexedEmdRecord[]>;
+}): IndexedEmdRecord {
+  const candidates = resolveSigunguRecords(args);
+  const prioritizedMatchKeys = buildAdministrativeNameMatchKeys(args.emdName);
+  const collapsedSubdivisionKey = buildCollapsedSubdivisionKey(args.emdName);
+  const matchKeys = collapsedSubdivisionKey
+    ? [...new Set([...prioritizedMatchKeys, collapsedSubdivisionKey])]
+    : prioritizedMatchKeys;
+
+  for (const matchKey of matchKeys) {
+    const matches = candidates.filter(
+      (candidate) => normalizeAdministrativeNameKey(candidate.emdName) === matchKey
+    );
+
+    if (matches.length === 1) {
+      const match = matches[0];
+      if (match) {
+        return match;
+      }
+    }
+
+    if (matches.length > 1) {
+      throw new Error(
+        `Resolved multiple 읍면동 rows for "${args.sigunguName} ${args.emdName}" in province "${args.provinceShortName}".`
+      );
+    }
+  }
+
+  throw new Error(
+    `Could not resolve 읍면동 "${args.sigunguName} ${args.emdName}" in province "${args.provinceShortName}".`
+  );
+}
+
+function listProvinceSigunguNames(args: {
+  provinceShortName: string;
+  sigunguIndex: Map<string, IndexedEmdRecord[]>;
+}): string[] {
+  const prefix = `${args.provinceShortName}|`;
+  return [...new Set(
+    [...args.sigunguIndex.entries()]
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([, records]) => records[0]?.sigunguName ?? "")
+      .filter(Boolean)
+  )];
+}
+
+function resolveSigunguPrefixFromToken(args: {
+  provinceShortName: string;
+  token: string;
+  sigunguIndex: Map<string, IndexedEmdRecord[]>;
+}): string | null {
+  const matches = listProvinceSigunguNames(args)
+    .filter((sigunguName) => args.token.startsWith(`${sigunguName} `))
+    .sort((left, right) => right.length - left.length);
+  return matches[0] ?? null;
+}
+
+function inferDefaultSigunguName(args: {
+  record: ConstituencyLawRecord;
+  sigunguIndex: Map<string, IndexedEmdRecord[]>;
+}): string | null {
+  const districtKeys = [
+    args.record.districtName,
+    args.record.districtName.replace(/특별자치시/g, "시").replace(/특별자치도/g, "도")
+  ].map((item) => normalizeAdministrativeNameKey(item));
+  const provinceSigunguNames = listProvinceSigunguNames({
+    provinceShortName: args.record.provinceShortName,
+    sigunguIndex: args.sigunguIndex
+  });
+  const matches = provinceSigunguNames
+    .filter((sigunguName) =>
+      districtKeys.some((districtKey) =>
+        districtKey.startsWith(normalizeAdministrativeNameKey(sigunguName))
+      )
+    )
+    .sort(
+      (left, right) =>
+        normalizeAdministrativeNameKey(right).length - normalizeAdministrativeNameKey(left).length
+    );
+
+  if (matches.length === 0 && provinceSigunguNames.length === 1) {
+    return provinceSigunguNames[0] ?? null;
+  }
+
+  return matches[0] ?? null;
+}
+
+function resolveLawRecordToEmdRecords(args: {
+  record: ConstituencyLawRecord;
+  sigunguIndex: Map<string, IndexedEmdRecord[]>;
+}): IndexedEmdRecord[] {
+  const selections = new Map<string, IndexedEmdRecord>();
+  let currentSigunguName = "";
+
+  for (const rawToken of args.record.areaText.split(",")) {
+    const token = normalizeLawCell(rawToken);
+    if (!token) {
+      continue;
+    }
+
+    if (token.endsWith("일원")) {
+      currentSigunguName = token.replace(/\s*일원$/, "").trim();
+      for (const item of resolveSigunguRecords({
+        provinceShortName: args.record.provinceShortName,
+        sigunguName: currentSigunguName,
+        sigunguIndex: args.sigunguIndex
+      })) {
+        selections.set(item.emdCode, item);
+      }
+      continue;
+    }
+
+    const tokenSigunguName = resolveSigunguPrefixFromToken({
+      provinceShortName: args.record.provinceShortName,
+      token,
+      sigunguIndex: args.sigunguIndex
+    });
+    if (tokenSigunguName) {
+      currentSigunguName = tokenSigunguName;
+      const emdName = token.slice(tokenSigunguName.length).trim();
+      const item = resolveEmdRecord({
+        provinceShortName: args.record.provinceShortName,
+        sigunguName: currentSigunguName,
+        emdName,
+        sigunguIndex: args.sigunguIndex
+      });
+      selections.set(item.emdCode, item);
+      continue;
+    }
+
+    if (!currentSigunguName) {
+      currentSigunguName =
+        inferDefaultSigunguName({
+          record: args.record,
+          sigunguIndex: args.sigunguIndex
+        }) ?? "";
+    }
+
+    if (!currentSigunguName) {
+      throw new Error(`Area token "${token}" in ${args.record.lawDistrictName} did not declare a sigungu context.`);
+    }
+
+    const item = resolveEmdRecord({
+      provinceShortName: args.record.provinceShortName,
+      sigunguName: currentSigunguName,
+      emdName: token,
+      sigunguIndex: args.sigunguIndex
+    });
+    selections.set(item.emdCode, item);
+  }
+
+  return [...selections.values()].sort((left, right) => left.emdCode.localeCompare(right.emdCode));
+}
+
+function buildTopology(records: IndexedEmdRecord[]): {
+  topology: Topology;
+  geometryByEmdCode: Map<string, TopologyGeometry>;
+} {
+  const featureCollection: GeoJsonFeatureCollection = {
+    type: "FeatureCollection",
+    features: records.map((record) => ({
+      type: "Feature",
+      id: record.emdCode,
+      properties: {
+        emdCode: record.emdCode
+      },
+      geometry: record.geometry
+    }))
+  };
+
+  const topology = topojsonServer.topology({
+    emd: featureCollection
+  });
+  const object = topology.objects.emd;
+  if (!object || object.type !== "GeometryCollection") {
+    throw new Error("Failed to construct a TopoJSON geometry collection for 읍면동 boundaries.");
+  }
+
+  const geometryByEmdCode = new Map<string, TopologyGeometry>();
+  for (const geometry of object.geometries) {
+    const emdCode =
+      typeof geometry.id === "string"
+        ? geometry.id
+        : typeof geometry.properties?.emdCode === "string"
+          ? geometry.properties.emdCode
+          : "";
+    if (!emdCode) {
+      throw new Error("Encountered a TopoJSON geometry without an 읍면동 code.");
+    }
+    geometryByEmdCode.set(emdCode, geometry);
+  }
+
+  return {
+    topology,
+    geometryByEmdCode
+  };
+}
+
+function buildConstituencyFeatures(args: {
+  lawRecords: ConstituencyLawRecord[];
+  indexedEmdRecords: IndexedEmdRecord[];
+}): ConstituencyBoundaryFeature[] {
+  const sigunguIndex = buildSigunguIndex(args.indexedEmdRecords);
+  const { topology, geometryByEmdCode } = buildTopology(args.indexedEmdRecords);
+
+  return args.lawRecords.map((record) => {
+    const province = provinceByFullName.get(record.provinceName);
+    if (!province) {
+      throw new Error(`Unknown province name "${record.provinceName}" in law parser output.`);
+    }
+
+    const emdRecords = resolveLawRecordToEmdRecords({
+      record,
+      sigunguIndex
+    });
+    const topologyGeometries = emdRecords.map((item) => {
+      const geometry = geometryByEmdCode.get(item.emdCode);
+      if (!geometry) {
+        throw new Error(`Missing TopoJSON geometry for 읍면동 ${item.emdCode}.`);
+      }
+      return geometry;
+    });
+    const geometry = topojsonClient.merge(topology, topologyGeometries);
+    const memberDistrictLabel = buildMemberDistrictLabel(province, record.districtName);
+    const memberDistrictKey = normalizeAdministrativeNameKey(memberDistrictLabel);
+    const sigunguCodes = [...new Set(emdRecords.map((item) => item.sigunguCode))].sort();
+    const officialSigunguCodes = [...new Set(emdRecords.map((item) => item.officialSigunguCode))].sort();
+    const sigunguNames = [...new Set(emdRecords.map((item) => item.sigunguName))].sort((left, right) =>
+      left.localeCompare(right, "ko")
+    );
+    const emdCodes = emdRecords.map((item) => item.emdCode);
+    const emdNames = emdRecords.map((item) => item.emdName);
+
+    return {
+      type: "Feature",
+      properties: {
+        constituencyId: memberDistrictKey,
+        lawDistrictName: record.lawDistrictName,
+        districtName: record.districtName,
+        memberDistrictLabel,
+        memberDistrictKey,
+        provinceName: province.fullName,
+        provinceShortName: province.shortName,
+        areaText: record.areaText,
+        aliases: buildDistrictAliases(province, record.districtName),
+        sigunguCodes: officialSigunguCodes.length > 0 ? officialSigunguCodes : sigunguCodes,
+        sigunguNames,
+        emdCodes,
+        emdNames
+      },
+      geometry
+    };
+  });
+}
+
+export function buildConstituencyBoundaryExport(args: {
+  generatedAt: string;
+  lawEffectiveDate: string;
+  lawSourceUrl: string;
+  lawText: string;
+  lawSource: ConstituencyBoundarySource;
+  sigunguCsv: string;
+  sigunguSource: ConstituencyBoundarySource;
+  emdCsv: string;
+  emdSource: ConstituencyBoundarySource;
+}): ConstituencyBoundaryExport {
+  const lawRecords = parseConstituencyLawText(args.lawText);
+  const sigunguRecords = parseNgiiSigunguCsv(args.sigunguCsv);
+  const emdRecords = parseNgiiEmdCsv(args.emdCsv);
+  const indexedEmdRecords = buildIndexedEmdRecords({
+    sigunguRecords,
+    emdRecords
+  });
+
+  return {
+    type: "FeatureCollection",
+    generatedAt: args.generatedAt,
+    lawEffectiveDate: args.lawEffectiveDate,
+    lawSourceUrl: args.lawSourceUrl,
+    sources: [
+      {
+        ...args.lawSource,
+        rowCount: lawRecords.length
+      },
+      {
+        ...args.sigunguSource,
+        rowCount: sigunguRecords.length
+      },
+      {
+        ...args.emdSource,
+        rowCount: emdRecords.length
+      }
+    ],
+    features: buildConstituencyFeatures({
+      lawRecords,
+      indexedEmdRecords
+    })
+  };
+}
+
+export function buildConstituencyBoundaryExportFromRecords(args: {
+  generatedAt: string;
+  lawEffectiveDate: string;
+  lawSourceUrl: string;
+  lawRecords: ConstituencyLawRecord[];
+  lawSource: ConstituencyBoundarySource;
+  indexedEmdRecords: IndexedEmdRecord[];
+  sigunguSource: ConstituencyBoundarySource;
+  emdSource: ConstituencyBoundarySource;
+}): ConstituencyBoundaryExport {
+  return {
+    type: "FeatureCollection",
+    generatedAt: args.generatedAt,
+    lawEffectiveDate: args.lawEffectiveDate,
+    lawSourceUrl: args.lawSourceUrl,
+    sources: [
+      {
+        ...args.lawSource,
+        rowCount: args.lawRecords.length
+      },
+      args.sigunguSource,
+      args.emdSource
+    ],
+    features: buildConstituencyFeatures({
+      lawRecords: args.lawRecords,
+      indexedEmdRecords: args.indexedEmdRecords
+    })
+  };
+}
+
+async function fetchBufferWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<DownloadedSource> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  const retrievedAt = new Date().toISOString();
+
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+    }
+
+    return {
+      content: Buffer.from(await response.arrayBuffer()),
+      retrievedAt
+    };
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error.name === "AbortError" || error.message.includes("aborted"))
+    ) {
+      throw new Error(`Request timed out for ${url} after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+function decodeCp949Csv(buffer: Buffer): string {
+  return iconv.decode(buffer, "cp949");
+}
+
+function buildSource(args: {
+  sourceId: string;
+  title: string;
+  sourcePageUrl?: string;
+  downloadUrl: string;
+  requestMethod?: "GET" | "POST";
+  requestBody?: string;
+  encoding?: string;
+  download: DownloadedSource;
+}): ConstituencyBoundarySource {
+  return {
+    sourceId: args.sourceId,
+    title: args.title,
+    sourcePageUrl: args.sourcePageUrl,
+    downloadUrl: args.downloadUrl,
+    requestMethod: args.requestMethod,
+    requestBody: args.requestBody,
+    encoding: args.encoding,
+    checksumSha256: sha256Buffer(args.download.content),
+    retrievedAt: args.download.retrievedAt
+  };
+}
+
+export async function fetchOfficialConstituencyBoundaryInputs(args?: {
+  timeoutMs?: number;
+}): Promise<{
+  law: DownloadedTextSource;
+  boundaryBundle: DownloadedBoundaryBundle;
+}> {
+  const timeoutMs = args?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const [lawDownload, sgisBoundaryDownload] = await Promise.all([
+    fetchBufferWithTimeout(
+      CONSTITUENCY_LAW_DOWNLOAD_URL,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded; charset=UTF-8"
+        },
+        body: CONSTITUENCY_LAW_DOWNLOAD_BODY
+      },
+      timeoutMs
+    ),
+    fetchBufferWithTimeout(SGIS_BOUNDARY_DOWNLOAD_URL, {}, timeoutMs)
+  ]);
+
+  return {
+    law: {
+      text: lawDownload.content.toString("utf8"),
+      source: buildSource({
+        sourceId: "law-go-kr-public-official-election-act-bylaw-1",
+        title: "공직선거법 별표 1 국회의원지역선거구구역표",
+        sourcePageUrl: CONSTITUENCY_LAW_PAGE_URL,
+        downloadUrl: CONSTITUENCY_LAW_DOWNLOAD_URL,
+        requestMethod: "POST",
+        requestBody: CONSTITUENCY_LAW_DOWNLOAD_BODY,
+        encoding: "utf-8",
+        download: lawDownload
+      })
+    },
+    boundaryBundle: await loadSgisBoundaryBundle({
+      download: sgisBoundaryDownload
+    })
+  };
+}

--- a/packages/ingest/src/constituency-boundary-runtime.ts
+++ b/packages/ingest/src/constituency-boundary-runtime.ts
@@ -1,0 +1,145 @@
+import { createRequire } from "node:module";
+
+import type {
+  ConstituencyBoundaryExport,
+  ConstituencyBoundaryFeature,
+  ConstituencyBoundariesIndexExport,
+  ConstituencyBoundariesIndexProvince
+} from "@lawmaker-monitor/schemas";
+
+import { sha256 } from "./utils.js";
+
+const require = createRequire(import.meta.url);
+const topojsonServer = require("topojson-server") as {
+  topology(objects: Record<string, GeoJsonFeatureCollection>): Topology;
+};
+
+type GeoJsonFeatureCollection = {
+  type: "FeatureCollection";
+  features: ConstituencyBoundaryFeature[];
+};
+
+type Topology = {
+  type: "Topology";
+  objects: Record<
+    string,
+    {
+      type: "GeometryCollection";
+      geometries: unknown[];
+    }
+  >;
+  arcs: unknown[];
+  bbox?: [number, number, number, number];
+  transform?: Record<string, unknown>;
+};
+
+export type ConstituencyBoundaryProvinceShard = ConstituencyBoundariesIndexProvince & {
+  content: string;
+  topology: Topology;
+};
+
+export type ConstituencyBoundaryRuntimeArtifacts = {
+  index: ConstituencyBoundariesIndexExport;
+  indexJson: string;
+  shards: ConstituencyBoundaryProvinceShard[];
+};
+
+export const CONSTITUENCY_BOUNDARIES_INDEX_PATH = "exports/constituency_boundaries/index.json";
+export const CONSTITUENCY_BOUNDARY_PROVINCES_DIR = "exports/constituency_boundaries/provinces";
+
+export function buildConstituencyBoundaryProvinceShardPath(provinceShortName: string): string {
+  return `${CONSTITUENCY_BOUNDARY_PROVINCES_DIR}/${provinceShortName}.topo.json`;
+}
+
+function cloneFeature(feature: ConstituencyBoundaryFeature): ConstituencyBoundaryFeature {
+  return {
+    type: "Feature",
+    properties: {
+      ...feature.properties,
+      aliases: [...feature.properties.aliases],
+      sigunguCodes: [...feature.properties.sigunguCodes],
+      sigunguNames: [...feature.properties.sigunguNames],
+      emdCodes: [...feature.properties.emdCodes],
+      emdNames: [...feature.properties.emdNames]
+    },
+    geometry: JSON.parse(JSON.stringify(feature.geometry)) as ConstituencyBoundaryFeature["geometry"]
+  };
+}
+
+function buildProvinceTopology(features: ConstituencyBoundaryFeature[]): Topology {
+  return topojsonServer.topology({
+    constituencies: {
+      type: "FeatureCollection",
+      features: features.map(cloneFeature)
+    }
+  });
+}
+
+export function buildConstituencyBoundaryRuntimeArtifacts(args: {
+  boundaryExport: ConstituencyBoundaryExport;
+  generatedAt: string;
+  snapshotId: string;
+}): ConstituencyBoundaryRuntimeArtifacts {
+  const provinces = new Map<string, ConstituencyBoundaryFeature[]>();
+
+  for (const feature of args.boundaryExport.features) {
+    const provinceShortName = feature.properties.provinceShortName;
+    const bucket = provinces.get(provinceShortName) ?? [];
+    bucket.push(feature);
+    provinces.set(provinceShortName, bucket);
+  }
+
+  const shards = [...provinces.entries()]
+    .sort(([leftProvince], [rightProvince]) => leftProvince.localeCompare(rightProvince, "ko"))
+    .map(([provinceShortName, features]) => {
+      const sortedFeatures = [...features].sort((left, right) =>
+        left.properties.memberDistrictKey.localeCompare(
+          right.properties.memberDistrictKey,
+          "ko"
+        )
+      );
+      const provinceName = sortedFeatures[0]?.properties.provinceName ?? provinceShortName;
+      const inconsistentProvince = sortedFeatures.find(
+        (feature) => feature.properties.provinceName !== provinceName
+      );
+
+      if (inconsistentProvince) {
+        throw new Error(
+          `Province shard ${provinceShortName} mixes province names ${provinceName} and ${inconsistentProvince.properties.provinceName}.`
+        );
+      }
+
+      const path = buildConstituencyBoundaryProvinceShardPath(provinceShortName);
+      const topology = buildProvinceTopology(sortedFeatures);
+      const content = JSON.stringify(topology);
+
+      return {
+        provinceName,
+        provinceShortName,
+        featureCount: sortedFeatures.length,
+        path,
+        checksumSha256: sha256(content),
+        content,
+        topology
+      };
+    });
+
+  const index = {
+    generatedAt: args.generatedAt,
+    snapshotId: args.snapshotId,
+    lawEffectiveDate: args.boundaryExport.lawEffectiveDate,
+    lawSourceUrl: args.boundaryExport.lawSourceUrl,
+    sourceGeneratedAt: args.boundaryExport.generatedAt,
+    sourceFeatureCount: args.boundaryExport.features.length,
+    sources: args.boundaryExport.sources.map((source) => ({
+      ...source
+    })),
+    provinces: shards.map(({ content: _content, topology: _topology, ...province }) => province)
+  } satisfies ConstituencyBoundariesIndexExport;
+
+  return {
+    index,
+    indexJson: JSON.stringify(index),
+    shards
+  };
+}

--- a/packages/ingest/src/exports.ts
+++ b/packages/ingest/src/exports.ts
@@ -1,6 +1,7 @@
 import type {
   AccountabilitySummaryExport,
   AccountabilityTrendsExport,
+  ConstituencyBoundariesIndexExport,
   CurrentAssembly,
   LatestVotesExport,
   Manifest,
@@ -26,6 +27,7 @@ type BuildArtifactsInput = {
   accountabilitySummary?: AccountabilitySummaryExport;
   accountabilityTrends?: AccountabilityTrendsExport;
   memberActivityCalendar?: MemberActivityCalendarExport;
+  constituencyBoundariesIndex?: ConstituencyBoundariesIndexExport;
 };
 
 type ExportBuildOptions = {
@@ -1358,6 +1360,7 @@ export function buildManifest(input: BuildArtifactsInput): Manifest {
     input.accountabilityTrends ?? buildAccountabilityTrendsExport(bundle);
   const memberActivityCalendar =
     input.memberActivityCalendar ?? buildMemberActivityCalendarExport(bundle);
+  const constituencyBoundariesIndex = input.constituencyBoundariesIndex;
   const normalizedPayloads = {
     members: toNdjson(bundle.members),
     rollCalls: toNdjson(bundle.rollCalls),
@@ -1408,7 +1411,16 @@ export function buildManifest(input: BuildArtifactsInput): Manifest {
         "exports/member_activity_calendar.json",
         memberActivityCalendar,
         memberActivityCalendar.assembly.members.length
-      )
+      ),
+      ...(constituencyBoundariesIndex
+        ? {
+            constituencyBoundariesIndex: createPublishedExportFile(
+              "exports/constituency_boundaries/index.json",
+              constituencyBoundariesIndex,
+              constituencyBoundariesIndex.provinces.length
+            )
+          }
+        : {})
     }
   };
 }

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./assembly-api.js";
+export * from "./constituency-boundary-runtime.js";
+export * from "./constituency-boundaries.js";
 export * from "./document-mirror.js";
 export * from "./exports.js";
 export * from "./normalize.js";

--- a/packages/ingest/src/scripts/build-constituency-boundaries.ts
+++ b/packages/ingest/src/scripts/build-constituency-boundaries.ts
@@ -1,0 +1,74 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildConstituencyBoundaryExportFromRecords,
+  CONSTITUENCY_LAW_EFFECTIVE_DATE,
+  CONSTITUENCY_LAW_PAGE_URL,
+  fetchOfficialConstituencyBoundaryInputs,
+  parseConstituencyLawText
+} from "../constituency-boundaries.js";
+import { validateConstituencyBoundaryExport } from "../validation.js";
+
+async function main(): Promise<void> {
+  const repositoryRoot = resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
+  const outputDir = resolve(
+    repositoryRoot,
+    process.env.OUTPUT_DIR ?? "artifacts/constituency-boundaries/current"
+  );
+  const generatedAt = process.env.GENERATED_AT ?? new Date().toISOString();
+  const timeoutMs = Number.parseInt(process.env.FETCH_TIMEOUT_MS ?? "", 10) || 120_000;
+
+  const inputs = await fetchOfficialConstituencyBoundaryInputs({
+    timeoutMs
+  });
+  const lawRecords = parseConstituencyLawText(inputs.law.text);
+
+  const boundaryExport = validateConstituencyBoundaryExport(
+    buildConstituencyBoundaryExportFromRecords({
+      generatedAt,
+      lawEffectiveDate: CONSTITUENCY_LAW_EFFECTIVE_DATE,
+      lawSourceUrl: CONSTITUENCY_LAW_PAGE_URL,
+      lawRecords,
+      lawSource: inputs.law.source,
+      indexedEmdRecords: inputs.boundaryBundle.indexedEmdRecords,
+      sigunguSource: inputs.boundaryBundle.sigunguSource,
+      emdSource: inputs.boundaryBundle.emdSource
+    })
+  );
+  const boundaryExportJson = JSON.stringify(boundaryExport);
+
+  await mkdir(outputDir, { recursive: true });
+
+  await Promise.all([
+    writeFile(join(outputDir, "constituency_boundaries.geojson"), boundaryExportJson),
+    writeFile(
+      join(outputDir, "source_manifest.json"),
+      JSON.stringify(
+        {
+          generatedAt,
+          lawEffectiveDate: CONSTITUENCY_LAW_EFFECTIVE_DATE,
+          lawSourceUrl: CONSTITUENCY_LAW_PAGE_URL,
+          sources: boundaryExport.sources,
+          featureCount: boundaryExport.features.length
+        },
+        null,
+        2
+      )
+    )
+  ]);
+
+  process.stdout.write(
+    [
+      `Wrote ${boundaryExport.features.length} constituency features.`,
+      `GeoJSON: ${join(outputDir, "constituency_boundaries.geojson")}`,
+      `Manifest: ${join(outputDir, "source_manifest.json")}`
+    ].join("\n")
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/ingest/src/scripts/build-data.ts
+++ b/packages/ingest/src/scripts/build-data.ts
@@ -2,7 +2,11 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { CurrentAssembly, NormalizedBundle } from "@lawmaker-monitor/schemas";
+import type {
+  ConstituencyBoundaryExport,
+  CurrentAssembly,
+  NormalizedBundle
+} from "@lawmaker-monitor/schemas";
 
 import {
   assertPublishedJsonFileSize,
@@ -15,6 +19,10 @@ import {
   serializePublishedJson,
   toNdjson
 } from "../exports.js";
+import {
+  buildConstituencyBoundaryRuntimeArtifacts,
+  CONSTITUENCY_BOUNDARIES_INDEX_PATH
+} from "../constituency-boundary-runtime.js";
 import { createNormalizedBundle } from "../normalize.js";
 import {
   createSourceRecord,
@@ -40,6 +48,7 @@ import {
   validateAccountabilitySummaryExport,
   validateAccountabilityTrendsExport,
   assertSinglePublicAssembly,
+  validateConstituencyBoundariesIndexExport,
   validateLatestVotesExport,
   validateManifest,
   validateMemberActivityCalendarExport,
@@ -112,6 +121,11 @@ async function writeBundle(outputDir: string, bundle: NormalizedBundle): Promise
 
 async function main(): Promise<void> {
   const repositoryRoot = resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
+  const constituencyBoundaryDir = resolvePathFromRoot(
+    repositoryRoot,
+    process.env.CONSTITUENCY_BOUNDARIES_DIR ??
+      join(repositoryRoot, "artifacts/constituency-boundaries/current")
+  );
   const rawRoot = resolvePathFromRoot(
     repositoryRoot,
     process.env.RAW_DIR ?? join(repositoryRoot, "tests/fixtures")
@@ -474,6 +488,21 @@ async function main(): Promise<void> {
   const memberActivityCalendarMemberDetails = builtMemberDetails.map((detail) =>
     validateMemberActivityCalendarMemberDetailExport(detail)
   );
+  // The boundary artifact is validated when it is built; build-data consumes and republishes it.
+  const constituencyBoundaryExport = JSON.parse(
+    await readFile(
+      join(constituencyBoundaryDir, "constituency_boundaries.geojson"),
+      "utf8"
+    )
+  ) as ConstituencyBoundaryExport;
+  const constituencyBoundaryRuntimeArtifacts = buildConstituencyBoundaryRuntimeArtifacts({
+    boundaryExport: constituencyBoundaryExport,
+    generatedAt: latestVotes.generatedAt,
+    snapshotId
+  });
+  const constituencyBoundariesIndex = validateConstituencyBoundariesIndexExport(
+    constituencyBoundaryRuntimeArtifacts.index
+  );
   const manifest = validateManifest(
     buildManifest({
       bundle,
@@ -482,7 +511,8 @@ async function main(): Promise<void> {
       latestVotes,
       accountabilitySummary,
       accountabilityTrends,
-      memberActivityCalendar
+      memberActivityCalendar,
+      constituencyBoundariesIndex
     })
   );
 
@@ -490,6 +520,7 @@ async function main(): Promise<void> {
   const accountabilitySummaryJson = serializePublishedJson(accountabilitySummary);
   const accountabilityTrendsJson = serializePublishedJson(accountabilityTrends);
   const memberActivityCalendarJson = serializePublishedJson(memberActivityCalendar);
+  const constituencyBoundariesIndexJson = constituencyBoundaryRuntimeArtifacts.indexJson;
   const manifestJson = JSON.stringify(manifest, null, 2);
   const memberActivityCalendarDetailWrites = memberActivityCalendarMemberDetails.map((detail) => {
     const relativePath = buildMemberActivityCalendarMemberDetailPath(detail.memberId);
@@ -504,8 +535,18 @@ async function main(): Promise<void> {
   assertPublishedJsonFileSize("exports/accountability_summary.json", accountabilitySummaryJson);
   assertPublishedJsonFileSize("exports/accountability_trends.json", accountabilityTrendsJson);
   assertPublishedJsonFileSize("exports/member_activity_calendar.json", memberActivityCalendarJson);
+  assertPublishedJsonFileSize(
+    CONSTITUENCY_BOUNDARIES_INDEX_PATH,
+    constituencyBoundariesIndexJson
+  );
+  for (const shard of constituencyBoundaryRuntimeArtifacts.shards) {
+    assertPublishedJsonFileSize(shard.path, shard.content);
+  }
 
   await mkdir(join(outputDir, "exports", "member_activity_calendar_members"), { recursive: true });
+  await mkdir(join(outputDir, "exports", "constituency_boundaries", "provinces"), {
+    recursive: true
+  });
 
   await Promise.all([
     writeFile(join(outputDir, "exports", "latest_votes.json"), latestVotesJson),
@@ -521,7 +562,14 @@ async function main(): Promise<void> {
       join(outputDir, "exports", "member_activity_calendar.json"),
       memberActivityCalendarJson
     ),
+    writeFile(
+      join(outputDir, CONSTITUENCY_BOUNDARIES_INDEX_PATH),
+      constituencyBoundariesIndexJson
+    ),
     writeFile(join(outputDir, "manifests", "latest.json"), manifestJson),
+    ...constituencyBoundaryRuntimeArtifacts.shards.map((shard) =>
+      writeFile(join(outputDir, shard.path), shard.content)
+    ),
     ...memberActivityCalendarDetailWrites.map((item) => writeFile(item.path, item.content))
   ]);
 }

--- a/packages/ingest/src/validation.ts
+++ b/packages/ingest/src/validation.ts
@@ -1,6 +1,8 @@
 import {
   accountabilitySummaryExportSchema,
   accountabilityTrendsExportSchema,
+  constituencyBoundaryExportSchema,
+  constituencyBoundariesIndexExportSchema,
   latestVotesExportSchema,
   manifestSchema,
   memberActivityCalendarExportSchema,
@@ -11,6 +13,8 @@ import {
 import type {
   AccountabilitySummaryExport,
   AccountabilityTrendsExport,
+  ConstituencyBoundaryExport,
+  ConstituencyBoundariesIndexExport,
   LatestVotesExport,
   Manifest,
   MemberActivityCalendarExport,
@@ -50,6 +54,18 @@ export function validateMemberActivityCalendarMemberDetailExport(
   payload: MemberActivityCalendarMemberDetailExport
 ): MemberActivityCalendarMemberDetailExport {
   return memberActivityCalendarMemberDetailExportSchema.parse(payload);
+}
+
+export function validateConstituencyBoundaryExport(
+  payload: ConstituencyBoundaryExport
+): ConstituencyBoundaryExport {
+  return constituencyBoundaryExportSchema.parse(payload);
+}
+
+export function validateConstituencyBoundariesIndexExport(
+  payload: ConstituencyBoundariesIndexExport
+): ConstituencyBoundariesIndexExport {
+  return constituencyBoundariesIndexExportSchema.parse(payload);
 }
 
 export function validateManifest(payload: Manifest): Manifest {

--- a/packages/schemas/src/contracts.ts
+++ b/packages/schemas/src/contracts.ts
@@ -270,6 +270,95 @@ export const memberActivityCalendarMemberDetailExportSchema = z.object({
   voteRecords: z.array(memberActivityVoteRecordSchema).default([])
 });
 
+const geoJsonPositionSchema = z.tuple([z.number(), z.number()]);
+
+const geoJsonLinearRingSchema = z.array(geoJsonPositionSchema).min(4);
+
+export const geoJsonPolygonSchema = z.object({
+  type: z.literal("Polygon"),
+  coordinates: z.array(geoJsonLinearRingSchema).min(1)
+});
+
+export const geoJsonMultiPolygonSchema = z.object({
+  type: z.literal("MultiPolygon"),
+  coordinates: z.array(z.array(geoJsonLinearRingSchema).min(1)).min(1)
+});
+
+export const constituencyBoundarySourceSchema = z
+  .object({
+    sourceId: nonEmptyString,
+    title: nonEmptyString,
+    sourcePageUrl: nonEmptyString.url().optional(),
+    downloadUrl: nonEmptyString.url(),
+    requestMethod: z.enum(["GET", "POST"]).optional(),
+    requestBody: nonEmptyString.optional(),
+    encoding: nonEmptyString.optional(),
+    checksumSha256: nonEmptyString,
+    retrievedAt: nonEmptyString,
+    rowCount: z.number().int().positive().optional()
+  })
+  .strict();
+
+export const constituencyBoundaryPropertiesSchema = z
+  .object({
+    constituencyId: nonEmptyString,
+    lawDistrictName: nonEmptyString,
+    districtName: nonEmptyString,
+    memberDistrictLabel: nonEmptyString,
+    memberDistrictKey: nonEmptyString,
+    provinceName: nonEmptyString,
+    provinceShortName: nonEmptyString,
+    areaText: nonEmptyString,
+    aliases: z.array(nonEmptyString).default([]),
+    sigunguCodes: z.array(nonEmptyString),
+    sigunguNames: z.array(nonEmptyString),
+    emdCodes: z.array(nonEmptyString),
+    emdNames: z.array(nonEmptyString)
+  })
+  .strict();
+
+export const constituencyBoundaryFeatureSchema = z
+  .object({
+    type: z.literal("Feature"),
+    properties: constituencyBoundaryPropertiesSchema,
+    geometry: z.union([geoJsonPolygonSchema, geoJsonMultiPolygonSchema])
+  })
+  .strict();
+
+export const constituencyBoundaryExportSchema = z
+  .object({
+    type: z.literal("FeatureCollection"),
+    generatedAt: nonEmptyString,
+    lawEffectiveDate: nonEmptyString,
+    lawSourceUrl: nonEmptyString.url(),
+    sources: z.array(constituencyBoundarySourceSchema).min(2),
+    features: z.array(constituencyBoundaryFeatureSchema).min(1)
+  })
+  .strict();
+
+export const constituencyBoundariesIndexProvinceSchema = z
+  .object({
+    provinceName: nonEmptyString,
+    provinceShortName: nonEmptyString,
+    featureCount: z.number().int().positive(),
+    path: nonEmptyString,
+    checksumSha256: nonEmptyString
+  })
+  .strict();
+
+export const constituencyBoundariesIndexExportSchema = z
+  .object({
+    generatedAt: nonEmptyString,
+    snapshotId: nonEmptyString,
+    lawEffectiveDate: nonEmptyString,
+    lawSourceUrl: nonEmptyString.url(),
+    sourceGeneratedAt: nonEmptyString,
+    sourceFeatureCount: z.number().int().positive(),
+    sources: z.array(constituencyBoundarySourceSchema).min(2),
+    provinces: z.array(constituencyBoundariesIndexProvinceSchema).min(1)
+  })
+  .strict();
+
 export const manifestSchema = z.object({
   schemaVersion: nonEmptyString,
   snapshotId: nonEmptyString,
@@ -287,7 +376,8 @@ export const manifestSchema = z.object({
     latestVotes: datasetFileSchema,
     accountabilitySummary: datasetFileSchema.optional(),
     memberActivityCalendar: datasetFileSchema.optional(),
-    accountabilityTrends: datasetFileSchema.optional()
+    accountabilityTrends: datasetFileSchema.optional(),
+    constituencyBoundariesIndex: datasetFileSchema.optional()
   })
 });
 
@@ -296,6 +386,7 @@ export const publishBundleSchema = z.object({
   latestVotes: latestVotesExportSchema,
   accountabilitySummary: accountabilitySummaryExportSchema,
   accountabilityTrends: accountabilityTrendsExportSchema.optional(),
+  constituencyBoundariesIndex: constituencyBoundariesIndexExportSchema.optional(),
   memberActivityCalendar: memberActivityCalendarExportSchema,
   memberActivityCalendarMemberDetails: z
     .array(memberActivityCalendarMemberDetailExportSchema)
@@ -319,6 +410,18 @@ export type MemberActivityCalendarAssembly = z.infer<typeof memberActivityCalend
 export type MemberActivityCalendarExport = z.infer<typeof memberActivityCalendarExportSchema>;
 export type MemberActivityCalendarMemberDetailExport = z.infer<
   typeof memberActivityCalendarMemberDetailExportSchema
+>;
+export type GeoJsonPolygon = z.infer<typeof geoJsonPolygonSchema>;
+export type GeoJsonMultiPolygon = z.infer<typeof geoJsonMultiPolygonSchema>;
+export type ConstituencyBoundarySource = z.infer<typeof constituencyBoundarySourceSchema>;
+export type ConstituencyBoundaryProperties = z.infer<typeof constituencyBoundaryPropertiesSchema>;
+export type ConstituencyBoundaryFeature = z.infer<typeof constituencyBoundaryFeatureSchema>;
+export type ConstituencyBoundaryExport = z.infer<typeof constituencyBoundaryExportSchema>;
+export type ConstituencyBoundariesIndexProvince = z.infer<
+  typeof constituencyBoundariesIndexProvinceSchema
+>;
+export type ConstituencyBoundariesIndexExport = z.infer<
+  typeof constituencyBoundariesIndexExportSchema
 >;
 export type Manifest = z.infer<typeof manifestSchema>;
 export type PublishBundle = z.infer<typeof publishBundleSchema>;

--- a/tests/fixtures/contracts/constituency_boundaries_index.json
+++ b/tests/fixtures/contracts/constituency_boundaries_index.json
@@ -1,0 +1,44 @@
+{
+  "generatedAt": "2026-03-22T11:45:00+09:00",
+  "snapshotId": "snapshot-20260322-114500",
+  "lawEffectiveDate": "2026-03-19",
+  "lawSourceUrl": "https://law.example.test/boundaries",
+  "sourceGeneratedAt": "2026-03-22T11:45:00+09:00",
+  "sourceFeatureCount": 2,
+  "sources": [
+    {
+      "sourceId": "law-table",
+      "title": "Current constituency law table",
+      "sourcePageUrl": "https://law.example.test/boundaries",
+      "downloadUrl": "https://law.example.test/boundaries/download",
+      "requestMethod": "GET",
+      "checksumSha256": "law-checksum",
+      "retrievedAt": "2026-03-22T11:45:00+09:00"
+    },
+    {
+      "sourceId": "sgis-admin",
+      "title": "Administrative boundary bundle",
+      "sourcePageUrl": "https://data.example.test/sgis",
+      "downloadUrl": "https://data.example.test/sgis/download",
+      "requestMethod": "GET",
+      "checksumSha256": "sgis-checksum",
+      "retrievedAt": "2026-03-22T11:45:00+09:00"
+    }
+  ],
+  "provinces": [
+    {
+      "provinceName": "부산광역시",
+      "provinceShortName": "부산",
+      "featureCount": 1,
+      "path": "exports/constituency_boundaries/provinces/부산.topo.json",
+      "checksumSha256": "busan-topo"
+    },
+    {
+      "provinceName": "서울특별시",
+      "provinceShortName": "서울",
+      "featureCount": 1,
+      "path": "exports/constituency_boundaries/provinces/서울.topo.json",
+      "checksumSha256": "seoul-topo"
+    }
+  ]
+}

--- a/tests/fixtures/contracts/constituency_province_busan.topo.json
+++ b/tests/fixtures/contracts/constituency_province_busan.topo.json
@@ -1,0 +1,79 @@
+{
+  "type": "Topology",
+  "objects": {
+    "constituencies": {
+      "type": "GeometryCollection",
+      "geometries": [
+        {
+          "type": "Polygon",
+          "properties": {
+            "constituencyId": "부산남구",
+            "lawDistrictName": "남구선거구",
+            "districtName": "남구",
+            "memberDistrictLabel": "부산 남구",
+            "memberDistrictKey": "부산남구",
+            "provinceName": "부산광역시",
+            "provinceShortName": "부산",
+            "areaText": "대연동, 용호동",
+            "aliases": [
+              "남구",
+              "부산 남구",
+              "부산남구",
+              "부산광역시 남구",
+              "부산광역시남구"
+            ],
+            "sigunguCodes": [
+              "26290"
+            ],
+            "sigunguNames": [
+              "남구"
+            ],
+            "emdCodes": [
+              "26290101",
+              "26290102"
+            ],
+            "emdNames": [
+              "대연동",
+              "용호동"
+            ]
+          },
+          "arcs": [
+            [
+              0
+            ]
+          ]
+        }
+      ]
+    }
+  },
+  "arcs": [
+    [
+      [
+        0,
+        0
+      ],
+      [
+        220,
+        0
+      ],
+      [
+        220,
+        180
+      ],
+      [
+        0,
+        180
+      ],
+      [
+        0,
+        0
+      ]
+    ]
+  ],
+  "bbox": [
+    0,
+    0,
+    220,
+    180
+  ]
+}

--- a/tests/fixtures/contracts/constituency_province_seoul.topo.json
+++ b/tests/fixtures/contracts/constituency_province_seoul.topo.json
@@ -1,0 +1,79 @@
+{
+  "type": "Topology",
+  "objects": {
+    "constituencies": {
+      "type": "GeometryCollection",
+      "geometries": [
+        {
+          "type": "Polygon",
+          "properties": {
+            "constituencyId": "서울중구",
+            "lawDistrictName": "중구선거구",
+            "districtName": "중구",
+            "memberDistrictLabel": "서울 중구",
+            "memberDistrictKey": "서울중구",
+            "provinceName": "서울특별시",
+            "provinceShortName": "서울",
+            "areaText": "명동, 회현동",
+            "aliases": [
+              "중구",
+              "서울 중구",
+              "서울중구",
+              "서울특별시 중구",
+              "서울특별시중구"
+            ],
+            "sigunguCodes": [
+              "11140"
+            ],
+            "sigunguNames": [
+              "중구"
+            ],
+            "emdCodes": [
+              "11140101",
+              "11140102"
+            ],
+            "emdNames": [
+              "명동",
+              "회현동"
+            ]
+          },
+          "arcs": [
+            [
+              0
+            ]
+          ]
+        }
+      ]
+    }
+  },
+  "arcs": [
+    [
+      [
+        20,
+        0
+      ],
+      [
+        210,
+        0
+      ],
+      [
+        240,
+        160
+      ],
+      [
+        30,
+        210
+      ],
+      [
+        20,
+        0
+      ]
+    ]
+  ],
+  "bbox": [
+    20,
+    0,
+    240,
+    210
+  ]
+}

--- a/tests/ingest/constituency-boundaries.test.ts
+++ b/tests/ingest/constituency-boundaries.test.ts
@@ -1,0 +1,334 @@
+import { createRequire } from "node:module";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildConstituencyBoundaryExport,
+  parseConstituencyLawText
+} from "../../packages/ingest/src/constituency-boundaries.js";
+import { validateConstituencyBoundaryExport } from "../../packages/ingest/src/validation.js";
+
+const require = createRequire(import.meta.url);
+const wkx = require("wkx") as {
+  Geometry: {
+    parseGeoJSON(input: unknown): {
+      toWkb(): Buffer;
+    };
+  };
+};
+
+function polygonHex(points: Array<[number, number]>): string {
+  return wkx.Geometry.parseGeoJSON({
+    type: "Polygon",
+    coordinates: [points]
+  })
+    .toWkb()
+    .toString("hex");
+}
+
+describe("constituency boundary builder", () => {
+  it("parses official law text rows and merges 읍면동 polygons into district features", () => {
+    const lawText = [
+      "  국회의원지역선거구구역표 (지역구 : 3)",
+      "│서울특별시(지역구 : 2)│",
+      "│종로구선거구      │종로구 일원│",
+      "│중구성동구갑선거구│성동구 왕십리제2동, 행당제1동,│",
+      "│                  │중구 일원│",
+      "│부산광역시(지역구 : 1)│",
+      "│남구선거구        │남구 일원│"
+    ].join("\n");
+
+    expect(parseConstituencyLawText(lawText)).toEqual([
+      {
+        provinceName: "서울특별시",
+        provinceShortName: "서울",
+        lawDistrictName: "종로구선거구",
+        districtName: "종로구",
+        areaText: "종로구 일원"
+      },
+      {
+        provinceName: "서울특별시",
+        provinceShortName: "서울",
+        lawDistrictName: "중구성동구갑선거구",
+        districtName: "중구성동구갑",
+        areaText: "성동구 왕십리제2동, 행당제1동,중구 일원"
+      },
+      {
+        provinceName: "부산광역시",
+        provinceShortName: "부산",
+        lawDistrictName: "남구선거구",
+        districtName: "남구",
+        areaText: "남구 일원"
+      }
+    ]);
+
+    const sigunguCsv = [
+      "공간정보일렬번호,시군구코드,시군구명,객체시군구코드,오브젝트아이디,공간정보",
+      "1,11110,종로구,11110,1,unused",
+      "2,11140,중구,11140,2,unused",
+      "3,11200,성동구,11200,3,unused",
+      "4,26290,남구,26290,4,unused"
+    ].join("\n");
+
+    const emdCsv = [
+      "공간정보일렬번호,읍면동코드,읍면동명,객체시군구코드,오브젝트아이디,공간정보",
+      `1,11110101,사직동,11110,1,${polygonHex([
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+        [0, 0]
+      ])}`,
+      `2,11110102,청운동,11110,2,${polygonHex([
+        [1, 0],
+        [2, 0],
+        [2, 1],
+        [1, 1],
+        [1, 0]
+      ])}`,
+      `3,11140101,소공동,11140,3,${polygonHex([
+        [0, 1],
+        [1, 1],
+        [1, 2],
+        [0, 2],
+        [0, 1]
+      ])}`,
+      `4,11200101,왕십리2동,11200,4,${polygonHex([
+        [1, 1],
+        [2, 1],
+        [2, 2],
+        [1, 2],
+        [1, 1]
+      ])}`,
+      `5,11200102,행당1동,11200,5,${polygonHex([
+        [2, 1],
+        [3, 1],
+        [3, 2],
+        [2, 2],
+        [2, 1]
+      ])}`,
+      `6,26290101,대연동,26290,6,${polygonHex([
+        [10, 10],
+        [11, 10],
+        [11, 11],
+        [10, 11],
+        [10, 10]
+      ])}`
+    ].join("\n");
+
+    const payload = validateConstituencyBoundaryExport(
+      buildConstituencyBoundaryExport({
+        generatedAt: "2026-03-28T16:00:00+09:00",
+        lawEffectiveDate: "2026-03-19",
+        lawSourceUrl:
+          "https://www.law.go.kr/lsBylInfoPLinkR.do?lsiSeq=284577&bylNo=0001&bylBrNo=00&bylCls=BE&bylEfYd=20260319&bylEfYdYn=Y",
+        lawText,
+        lawSource: {
+          sourceId: "law",
+          title: "공직선거법 별표 1",
+          downloadUrl: "https://www.law.go.kr/LSW/lsBylTextDownLoad.do",
+          checksumSha256: "law-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        },
+        sigunguCsv,
+        sigunguSource: {
+          sourceId: "sigungu",
+          title: "시군구 CSV",
+          downloadUrl: "https://www.data.go.kr/sigungu.csv",
+          checksumSha256: "sigungu-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        },
+        emdCsv,
+        emdSource: {
+          sourceId: "emd",
+          title: "읍면동 CSV",
+          downloadUrl: "https://www.data.go.kr/emd.csv",
+          checksumSha256: "emd-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        }
+      })
+    );
+
+    expect(payload.features).toHaveLength(3);
+    expect(payload.sources.map((source) => source.rowCount)).toEqual([3, 4, 6]);
+
+    const jongno = payload.features[0];
+    const jungSeongdongGap = payload.features[1];
+
+    expect(jongno?.properties.memberDistrictLabel).toBe("서울 종로구");
+    expect(jongno?.properties.aliases).toContain("서울 종로구");
+    expect(jungSeongdongGap?.properties.memberDistrictKey).toBe("서울중구성동구갑");
+    expect(jungSeongdongGap?.properties.sigunguNames).toEqual(["성동구", "중구"]);
+    expect(jungSeongdongGap?.properties.emdNames).toEqual(["소공동", "왕십리2동", "행당1동"]);
+    expect(["Polygon", "MultiPolygon"]).toContain(jungSeongdongGap?.geometry.type);
+  });
+
+  it("accepts duplicated and ordinal law suffixes when SGIS names omit the marker", () => {
+    const lawText = [
+      "│서울특별시(지역구 : 1)│",
+      "│서대문구선거구│홍제제1동, 홍제제2동│"
+    ].join("\n");
+
+    const sigunguCsv = [
+      "공간정보일렬번호,시군구코드,시군구명,객체시군구코드,오브젝트아이디,공간정보",
+      "1,11130,서대문구,11130,1,unused"
+    ].join("\n");
+
+    const emdCsv = [
+      "공간정보일렬번호,읍면동코드,읍면동명,객체시군구코드,오브젝트아이디,공간정보",
+      `1,11130620,홍제1동,11130,1,${polygonHex([
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+        [0, 0]
+      ])}`,
+      `2,11130650,홍제2동,11130,2,${polygonHex([
+        [1, 0],
+        [2, 0],
+        [2, 1],
+        [1, 1],
+        [1, 0]
+      ])}`
+    ].join("\n");
+
+    const payload = validateConstituencyBoundaryExport(
+      buildConstituencyBoundaryExport({
+        generatedAt: "2026-03-28T16:00:00+09:00",
+        lawEffectiveDate: "2026-03-19",
+        lawSourceUrl: "https://example.com/law",
+        lawText,
+        lawSource: {
+          sourceId: "law",
+          title: "공직선거법 별표 1",
+          downloadUrl: "https://example.com/law.txt",
+          checksumSha256: "law-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        },
+        sigunguCsv,
+        sigunguSource: {
+          sourceId: "sigungu",
+          title: "시군구 CSV",
+          downloadUrl: "https://example.com/sigungu.csv",
+          checksumSha256: "sigungu-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        },
+        emdCsv,
+        emdSource: {
+          sourceId: "emd",
+          title: "읍면동 CSV",
+          downloadUrl: "https://example.com/emd.csv",
+          checksumSha256: "emd-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        }
+      })
+    );
+
+    expect(payload.features).toHaveLength(1);
+    expect(payload.features[0]?.properties.emdNames).toEqual(["홍제1동", "홍제2동"]);
+  });
+
+  it("collapses historical numeric subdivisions into a merged administrative dong when SGIS only has the merged name", () => {
+    const lawText = [
+      "│전북특별자치도(지역구 : 1)│",
+      "│전주시병선거구│전주시 덕진구 금암1동, 금암2동│"
+    ].join("\n");
+
+    const sigunguCsv = [
+      "공간정보일렬번호,시군구코드,시군구명,객체시군구코드,오브젝트아이디,공간정보",
+      "1,45113,전주시 덕진구,45113,1,unused"
+    ].join("\n");
+
+    const emdCsv = [
+      "공간정보일렬번호,읍면동코드,읍면동명,객체시군구코드,오브젝트아이디,공간정보",
+      `1,45113710,금암동,45113,1,${polygonHex([
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+        [0, 0]
+      ])}`
+    ].join("\n");
+
+    const payload = validateConstituencyBoundaryExport(
+      buildConstituencyBoundaryExport({
+        generatedAt: "2026-03-28T16:00:00+09:00",
+        lawEffectiveDate: "2026-03-19",
+        lawSourceUrl: "https://example.com/law",
+        lawText,
+        lawSource: {
+          sourceId: "law",
+          title: "공직선거법 별표 1",
+          downloadUrl: "https://example.com/law.txt",
+          checksumSha256: "law-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        },
+        sigunguCsv,
+        sigunguSource: {
+          sourceId: "sigungu",
+          title: "시군구 CSV",
+          downloadUrl: "https://example.com/sigungu.csv",
+          checksumSha256: "sigungu-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        },
+        emdCsv,
+        emdSource: {
+          sourceId: "emd",
+          title: "읍면동 CSV",
+          downloadUrl: "https://example.com/emd.csv",
+          checksumSha256: "emd-checksum",
+          retrievedAt: "2026-03-28T16:00:00+09:00"
+        }
+      })
+    );
+
+    expect(payload.features).toHaveLength(1);
+    expect(payload.features[0]?.properties.emdNames).toEqual(["금암동"]);
+  });
+
+  it("keeps district names intact when the law table wraps the left cell with a standalone 선거구 row", () => {
+    const lawText = [
+      "│인천광역시(지역구 : 1)│",
+      "│동구미추홀구갑│미추홀구 도화1동, 주안1동,│",
+      "│선거구        │주안6동, 동구 일원│"
+    ].join("\n");
+
+    expect(parseConstituencyLawText(lawText)).toEqual([
+      {
+        provinceName: "인천광역시",
+        provinceShortName: "인천",
+        lawDistrictName: "동구미추홀구갑선거구",
+        districtName: "동구미추홀구갑",
+        areaText: "미추홀구 도화1동, 주안1동,주안6동, 동구 일원"
+      }
+    ]);
+  });
+
+  it("reconstructs wrapped district labels and sigungu prefixes across table rows", () => {
+    const lawText = [
+      "│경기도(지역구 : 1)│",
+      "│수원시무선거구│수원시 권선구 세류2동, 곡선동, 수원시 영통구│",
+      "│            │영통2동, 망포1동│",
+      "│강원특별자치도(지역구 : 1)│",
+      "│춘천시철원군화천군│춘천시 동산면, 교동│",
+      "│양구군갑선거구    │소양동, 후평1동│"
+    ].join("\n");
+
+    expect(parseConstituencyLawText(lawText)).toEqual([
+      {
+        provinceName: "경기도",
+        provinceShortName: "경기",
+        lawDistrictName: "수원시무선거구",
+        districtName: "수원시무",
+        areaText: "수원시 권선구 세류2동, 곡선동, 수원시 영통구 영통2동, 망포1동"
+      },
+      {
+        provinceName: "강원특별자치도",
+        provinceShortName: "강원",
+        lawDistrictName: "춘천시철원군화천군양구군갑선거구",
+        districtName: "춘천시철원군화천군양구군갑",
+        areaText: "춘천시 동산면, 교동 소양동, 후평1동"
+      }
+    ]);
+  });
+});

--- a/tests/ingest/constituency-boundary-runtime.test.ts
+++ b/tests/ingest/constituency-boundary-runtime.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+
+import type { ConstituencyBoundaryExport } from "../../packages/schemas/src/index.js";
+
+import {
+  buildConstituencyBoundaryProvinceShardPath,
+  buildConstituencyBoundaryRuntimeArtifacts,
+  CONSTITUENCY_BOUNDARIES_INDEX_PATH
+} from "../../packages/ingest/src/constituency-boundary-runtime.js";
+import {
+  assertPublishedJsonFileSize,
+  buildManifest,
+  serializePublishedJson
+} from "../../packages/ingest/src/exports.js";
+import { createNormalizedBundle } from "../../packages/ingest/src/normalize.js";
+import { sha256 } from "../../packages/ingest/src/utils.js";
+import {
+  validateConstituencyBoundariesIndexExport,
+  validateManifest
+} from "../../packages/ingest/src/validation.js";
+
+function polygon(
+  west: number,
+  south: number,
+  east: number,
+  north: number
+): Array<Array<[number, number]>> {
+  return [[
+    [west, south],
+    [east, south],
+    [east, north],
+    [west, north],
+    [west, south]
+  ]];
+}
+
+function createBoundaryExport(): ConstituencyBoundaryExport {
+  return {
+    type: "FeatureCollection",
+    generatedAt: "2026-03-28T07:20:49.255Z",
+    lawEffectiveDate: "2026-03-19",
+    lawSourceUrl:
+      "https://www.law.go.kr/lsBylInfoPLinkR.do?lsiSeq=284577&bylNo=0001&bylBrNo=00&bylCls=BE&bylEfYd=20260319&bylEfYdYn=Y",
+    sources: [
+      {
+        sourceId: "law",
+        title: "Official election law district table",
+        sourcePageUrl: "https://www.law.go.kr/lsBylInfoPLinkR.do?lsiSeq=284577",
+        downloadUrl: "https://www.law.go.kr/LSW/lsBylTextDownLoad.do",
+        requestMethod: "POST",
+        requestBody: "bylSeq=18012299&mode=0",
+        encoding: "utf-8",
+        checksumSha256: "law-checksum",
+        retrievedAt: "2026-03-28T07:20:49.255Z",
+        rowCount: 3
+      },
+      {
+        sourceId: "sgis-sigungu",
+        title: "Official sigungu boundary bundle",
+        sourcePageUrl: "https://www.data.go.kr/data/15129688/fileData.do",
+        downloadUrl:
+          "https://www.data.go.kr/cmm/cmm/fileDownload.do?atchFileId=FILE_000000003601705",
+        requestMethod: "GET",
+        encoding: "utf-8",
+        checksumSha256: "sigungu-checksum",
+        retrievedAt: "2026-03-28T07:20:49.274Z",
+        rowCount: 2
+      },
+      {
+        sourceId: "sgis-emd",
+        title: "Official administrative dong boundary bundle",
+        sourcePageUrl: "https://www.data.go.kr/data/15129688/fileData.do",
+        downloadUrl:
+          "https://www.data.go.kr/cmm/cmm/fileDownload.do?atchFileId=FILE_000000003601705",
+        requestMethod: "GET",
+        encoding: "utf-8",
+        checksumSha256: "emd-checksum",
+        retrievedAt: "2026-03-28T07:20:49.274Z",
+        rowCount: 4
+      }
+    ],
+    features: [
+      {
+        type: "Feature",
+        properties: {
+          constituencyId: "서울종로구",
+          lawDistrictName: "종로구선거구",
+          districtName: "종로구",
+          memberDistrictLabel: "서울 종로구",
+          memberDistrictKey: "서울종로구",
+          provinceName: "서울특별시",
+          provinceShortName: "서울",
+          areaText: "종로구 일원",
+          aliases: ["서울 종로구"],
+          sigunguCodes: ["11110"],
+          sigunguNames: ["종로구"],
+          emdCodes: ["11110101"],
+          emdNames: ["사직동"]
+        },
+        geometry: {
+          type: "Polygon",
+          coordinates: polygon(126.9, 37.55, 126.98, 37.61)
+        }
+      },
+      {
+        type: "Feature",
+        properties: {
+          constituencyId: "서울중구",
+          lawDistrictName: "중구선거구",
+          districtName: "중구",
+          memberDistrictLabel: "서울 중구",
+          memberDistrictKey: "서울중구",
+          provinceName: "서울특별시",
+          provinceShortName: "서울",
+          areaText: "중구 일원",
+          aliases: ["서울 중구"],
+          sigunguCodes: ["11140"],
+          sigunguNames: ["중구"],
+          emdCodes: ["11140101"],
+          emdNames: ["소공동"]
+        },
+        geometry: {
+          type: "Polygon",
+          coordinates: polygon(126.98, 37.55, 127.04, 37.61)
+        }
+      },
+      {
+        type: "Feature",
+        properties: {
+          constituencyId: "부산남구",
+          lawDistrictName: "남구선거구",
+          districtName: "남구",
+          memberDistrictLabel: "부산 남구",
+          memberDistrictKey: "부산남구",
+          provinceName: "부산광역시",
+          provinceShortName: "부산",
+          areaText: "남구 일원",
+          aliases: ["부산 남구"],
+          sigunguCodes: ["26290"],
+          sigunguNames: ["남구"],
+          emdCodes: ["26290101"],
+          emdNames: ["대연동"]
+        },
+        geometry: {
+          type: "Polygon",
+          coordinates: polygon(129.08, 35.1, 129.16, 35.18)
+        }
+      }
+    ]
+  };
+}
+
+describe("constituency boundary runtime artifacts", () => {
+  it("builds province shards and wires the manifest export entry", () => {
+    const runtimeArtifacts = buildConstituencyBoundaryRuntimeArtifacts({
+      boundaryExport: createBoundaryExport(),
+      generatedAt: "2026-03-28T08:00:00.000Z",
+      snapshotId: "snapshot-22"
+    });
+    const index = validateConstituencyBoundariesIndexExport(runtimeArtifacts.index);
+
+    expect(index.provinces).toEqual([
+      {
+        provinceName: "부산광역시",
+        provinceShortName: "부산",
+        featureCount: 1,
+        path: buildConstituencyBoundaryProvinceShardPath("부산"),
+        checksumSha256: runtimeArtifacts.shards[0]?.checksumSha256
+      },
+      {
+        provinceName: "서울특별시",
+        provinceShortName: "서울",
+        featureCount: 2,
+        path: buildConstituencyBoundaryProvinceShardPath("서울"),
+        checksumSha256: runtimeArtifacts.shards[1]?.checksumSha256
+      }
+    ]);
+    expect(JSON.parse(runtimeArtifacts.shards[1]?.content ?? "{}")).toMatchObject({
+      type: "Topology",
+      objects: {
+        constituencies: {
+          type: "GeometryCollection",
+          geometries: expect.arrayContaining([
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                memberDistrictKey: "서울종로구"
+              })
+            })
+          ])
+        }
+      }
+    });
+
+    const bundle = createNormalizedBundle({
+      members: [],
+      rollCalls: [],
+      voteFacts: [],
+      meetings: [],
+      sources: [],
+      agendas: []
+    });
+    const manifest = validateManifest(
+      buildManifest({
+        bundle,
+        dataRepoBaseUrl: "https://data.example.test/lawmaker-monitor/",
+        currentAssembly: {
+          assemblyNo: 22,
+          label: "제22대 국회",
+          unitCd: "100022"
+        },
+        latestVotes: {
+          generatedAt: "2026-03-28T08:00:00.000Z",
+          snapshotId: "snapshot-22",
+          assemblyNo: 22,
+          assemblyLabel: "제22대 국회",
+          items: []
+        },
+        accountabilitySummary: {
+          generatedAt: "2026-03-28T08:00:00.000Z",
+          snapshotId: "snapshot-22",
+          assemblyNo: 22,
+          assemblyLabel: "제22대 국회",
+          items: []
+        },
+        accountabilityTrends: {
+          generatedAt: "2026-03-28T08:00:00.000Z",
+          snapshotId: "snapshot-22",
+          assemblyNo: 22,
+          assemblyLabel: "제22대 국회",
+          weeks: [],
+          movers: []
+        },
+        memberActivityCalendar: {
+          generatedAt: "2026-03-28T08:00:00.000Z",
+          snapshotId: "snapshot-22",
+          assemblyNo: 22,
+          assemblyLabel: "제22대 국회",
+          assembly: {
+            assemblyNo: 22,
+            label: "제22대 국회",
+            startDate: "2026-01-01",
+            endDate: "2026-12-31",
+            votingDates: [],
+            members: []
+          }
+        },
+        constituencyBoundariesIndex: index
+      })
+    );
+
+    expect(manifest.exports.constituencyBoundariesIndex?.path).toBe(
+      CONSTITUENCY_BOUNDARIES_INDEX_PATH
+    );
+    expect(manifest.exports.constituencyBoundariesIndex?.rowCount).toBe(2);
+    expect(manifest.exports.constituencyBoundariesIndex?.checksumSha256).toBe(
+      sha256(serializePublishedJson(index))
+    );
+  });
+
+  it("keeps the published boundary index and shards under the JSON size guard", () => {
+    const runtimeArtifacts = buildConstituencyBoundaryRuntimeArtifacts({
+      boundaryExport: createBoundaryExport(),
+      generatedAt: "2026-03-28T08:00:00.000Z",
+      snapshotId: "snapshot-22"
+    });
+
+    expect(() =>
+      assertPublishedJsonFileSize(CONSTITUENCY_BOUNDARIES_INDEX_PATH, runtimeArtifacts.indexJson)
+    ).not.toThrow();
+    for (const shard of runtimeArtifacts.shards) {
+      expect(() => assertPublishedJsonFileSize(shard.path, shard.content)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a reproducible `build:constituency-boundaries` ingest pipeline backed by official law and SGIS boundary sources
- publish constituency boundary runtime index/shards through `build-data` and include the export in the manifest contract
- materialize the constituency boundary source artifact in `.github/workflows/build-data.yml` before normalized data publication

## Validation
- `npm run build --workspace @lawmaker-monitor/schemas`
- `npm run build --workspace @lawmaker-monitor/ingest`
- `npx vitest run tests/ingest/constituency-boundaries.test.ts tests/ingest/constituency-boundary-runtime.test.ts`
- `npm run build:constituency-boundaries --workspace @lawmaker-monitor/ingest`
- `RAW_DIR=tests/fixtures OUTPUT_DIR=$(mktemp -d /tmp/lawmaker-monitor-build-data-XXXXXX) npm run build:data --workspace @lawmaker-monitor/ingest`
