### PR TITLE
NIT-349 publish constituency map panel to main

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,8 @@
     "html-to-image": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "recharts": "^3.8.0"
+    "recharts": "^3.8.0",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.24",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -447,6 +447,7 @@ export default function App() {
       <DistributionPage
         accountabilitySummary={accountabilitySummary}
         activityCalendar={activityCalendar}
+        manifest={manifest}
         loading={
           (!accountabilitySummary && !leaderboardError) ||
           (!activityCalendar && !activityError)

--- a/apps/web/src/components/DistributionConstituencyMap.tsx
+++ b/apps/web/src/components/DistributionConstituencyMap.tsx
@@ -1,0 +1,607 @@
+import { useEffect, useMemo, useState } from "react";
+
+import type {
+  ConstituencyBoundariesIndexExport,
+  Manifest
+} from "@lawmaker-monitor/schemas";
+
+import {
+  buildConstituencyMapRegions,
+  getConstituencyMetricValue,
+  resolveProvinceForDistrict,
+  type ConstituencyBoundaryTopology,
+  type ConstituencyMapRegion,
+  type ConstituencyMetricMode
+} from "../lib/constituency-map.js";
+import {
+  loadConstituencyBoundariesIndex,
+  loadConstituencyProvinceTopology
+} from "../lib/data.js";
+import type { DistributionMemberPoint } from "../lib/distribution.js";
+import { formatNumber, formatPercent } from "../lib/format.js";
+import { MemberIdentity } from "./MemberIdentity.js";
+
+type DistributionConstituencyMapProps = {
+  manifest: Manifest | null;
+  members: DistributionMemberPoint[];
+  highlightedMemberIds: ReadonlySet<string>;
+  selectedMemberId: string | null;
+  onSelectMember: (memberId: string) => void;
+};
+
+const MAP_WIDTH = 920;
+const MAP_HEIGHT = 760;
+const COLOR_LOW = "#f6e8d5";
+const COLOR_HIGH = "#7b3128";
+const METRIC_OPTIONS: Array<{
+  key: ConstituencyMetricMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "absent",
+    label: "불참 비중",
+    description: "진한 색일수록 해당 지역구 대표 의원의 불참 비중이 높습니다."
+  },
+  {
+    key: "negative",
+    label: "반대·기권 비중",
+    description: "진한 색일수록 반대·기권 비중이 높습니다."
+  },
+  {
+    key: "attendance",
+    label: "출석률",
+    description: "진한 색일수록 출석률이 낮습니다."
+  }
+];
+
+function mixHexColor(startHex: string, endHex: string, ratio: number): string {
+  const normalized = Math.min(1, Math.max(0, ratio));
+  const start = startHex.replace("#", "");
+  const end = endHex.replace("#", "");
+  const channels = [0, 2, 4].map((offset) => {
+    const left = Number.parseInt(start.slice(offset, offset + 2), 16);
+    const right = Number.parseInt(end.slice(offset, offset + 2), 16);
+    const value = Math.round(left + (right - left) * normalized);
+    return value.toString(16).padStart(2, "0");
+  });
+
+  return `#${channels.join("")}`;
+}
+
+function getRegionFill(region: ConstituencyMapRegion, metricMode: ConstituencyMetricMode): string {
+  if (!region.member) {
+    return "rgba(214, 203, 191, 0.45)";
+  }
+
+  if (!region.highlighted) {
+    return "rgba(191, 178, 163, 0.42)";
+  }
+
+  const rawValue = getConstituencyMetricValue(region.member, metricMode);
+  const intensity = metricMode === "attendance" ? 1 - rawValue : rawValue;
+  return mixHexColor(COLOR_LOW, COLOR_HIGH, Math.max(0.14, Math.min(0.96, intensity)));
+}
+
+function getActiveMetricMeta(metricMode: ConstituencyMetricMode) {
+  return (
+    METRIC_OPTIONS.find((metric) => metric.key === metricMode) ?? {
+      key: "absent",
+      label: "불참 비중",
+      description: "진한 색일수록 해당 지역구 대표 의원의 불참 비중이 높습니다."
+    }
+  );
+}
+
+function buildRegionScopeText(args: {
+  matchedRegions: ConstituencyMapRegion[];
+  highlightedRegions: ConstituencyMapRegion[];
+  totalRegions: number;
+}): string {
+  if (args.totalRegions === 0) {
+    return "표시할 지역구가 없습니다.";
+  }
+
+  if (args.highlightedRegions.length === args.matchedRegions.length) {
+    return `현재 province에서 ${formatNumber(args.matchedRegions.length)}개 지역구 통계를 연결했습니다.`;
+  }
+
+  return `필터 조건 안에서 ${formatNumber(args.highlightedRegions.length)}개 지역구를 강조하고, 나머지 ${formatNumber(args.matchedRegions.length - args.highlightedRegions.length)}개는 옅게 유지합니다.`;
+}
+
+function DistributionConstituencyMapDetail({
+  region,
+  selectedMemberId,
+  onSelectMember
+}: {
+  region: ConstituencyMapRegion | null;
+  selectedMemberId: string | null;
+  onSelectMember: (memberId: string) => void;
+}) {
+  if (!region) {
+    return (
+      <aside className="distribution-map__detail" aria-live="polite">
+        <p className="section-label">선택 지역구</p>
+        <h3>지도에서 지역구를 선택해 주세요.</h3>
+        <p className="distribution-page__search-note">
+          지도 클릭 또는 province 전환으로 지역구별 통계를 살펴볼 수 있습니다.
+        </p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="distribution-map__detail" aria-live="polite">
+      <p className="section-label">선택 지역구</p>
+      <h3>{region.properties.memberDistrictLabel}</h3>
+      <p className="distribution-map__detail-area">{region.properties.areaText}</p>
+      {region.member ? (
+        <>
+          <MemberIdentity
+            name={region.member.name}
+            party={region.member.party}
+            photoUrl={region.member.photoUrl}
+            size="large"
+          />
+          <div className="distribution-map__detail-actions">
+            <button
+              type="button"
+              className="distribution-map__detail-action"
+              onClick={() => onSelectMember(region.member!.memberId)}
+              disabled={selectedMemberId === region.member.memberId}
+            >
+              {selectedMemberId === region.member.memberId
+                ? "현재 분포 상세와 연결됨"
+                : "이 의원 상세와 연결"}
+            </button>
+          </div>
+          <div className="distribution-map__detail-metrics">
+            <article>
+              <span>출석률</span>
+              <strong>{formatPercent(region.member.attendanceRate)}</strong>
+            </article>
+            <article>
+              <span>불참 비중</span>
+              <strong>{formatPercent(region.member.absentRate)}</strong>
+            </article>
+            <article>
+              <span>반대·기권 비중</span>
+              <strong>{formatPercent(region.member.negativeRate)}</strong>
+            </article>
+            <article>
+              <span>현재 연속 패턴</span>
+              <strong>{`${formatNumber(region.member.currentNegativeOrAbsentStreak)}일`}</strong>
+            </article>
+          </div>
+          <dl className="distribution-map__detail-facts">
+            <div>
+              <dt>대표 의원</dt>
+              <dd>{`${region.member.name} · ${region.member.party}`}</dd>
+            </div>
+            <div>
+              <dt>기록표결</dt>
+              <dd>{`${formatNumber(region.member.totalRecordedVotes)}건`}</dd>
+            </div>
+            <div>
+              <dt>시군구</dt>
+              <dd>{region.properties.sigunguNames.join(", ")}</dd>
+            </div>
+            <div>
+              <dt>읍면동 수</dt>
+              <dd>{`${formatNumber(region.properties.emdNames.length)}개`}</dd>
+            </div>
+          </dl>
+        </>
+      ) : (
+        <>
+          <p className="distribution-page__search-note">
+            이 지역구는 boundary는 준비됐지만 현재 의원 통계 export와의 연결이 아직 없습니다.
+          </p>
+          <dl className="distribution-map__detail-facts">
+            <div>
+              <dt>시군구</dt>
+              <dd>{region.properties.sigunguNames.join(", ")}</dd>
+            </div>
+            <div>
+              <dt>읍면동 수</dt>
+              <dd>{`${formatNumber(region.properties.emdNames.length)}개`}</dd>
+            </div>
+          </dl>
+        </>
+      )}
+    </aside>
+  );
+}
+
+export function DistributionConstituencyMap({
+  manifest,
+  members,
+  highlightedMemberIds,
+  selectedMemberId,
+  onSelectMember
+}: DistributionConstituencyMapProps) {
+  const [boundaryIndex, setBoundaryIndex] = useState<ConstituencyBoundariesIndexExport | null>(null);
+  const [isIndexLoading, setIsIndexLoading] = useState(false);
+  const [indexError, setIndexError] = useState<string | null>(null);
+  const [activeProvinceShortName, setActiveProvinceShortName] = useState<string | null>(null);
+  const [provinceTopologies, setProvinceTopologies] = useState<
+    Record<string, ConstituencyBoundaryTopology | null | undefined>
+  >({});
+  const [isProvinceLoading, setIsProvinceLoading] = useState(false);
+  const [provinceError, setProvinceError] = useState<string | null>(null);
+  const [selectedDistrictKey, setSelectedDistrictKey] = useState<string | null>(null);
+  const [metricMode, setMetricMode] = useState<ConstituencyMetricMode>("absent");
+
+  const selectedMember = useMemo(
+    () => members.find((member) => member.memberId === selectedMemberId) ?? null,
+    [members, selectedMemberId]
+  );
+  const preferredProvince = useMemo(
+    () =>
+      boundaryIndex
+        ? resolveProvinceForDistrict(selectedMember?.district ?? null, boundaryIndex.provinces)
+        : null,
+    [boundaryIndex, selectedMember?.district]
+  );
+  const activeProvince = useMemo(
+    () =>
+      activeProvinceShortName && boundaryIndex
+        ? boundaryIndex.provinces.find(
+            (province) => province.provinceShortName === activeProvinceShortName
+          ) ?? null
+        : null,
+    [activeProvinceShortName, boundaryIndex]
+  );
+  const activeTopology =
+    activeProvinceShortName !== null ? provinceTopologies[activeProvinceShortName] : undefined;
+
+  useEffect(() => {
+    let active = true;
+    setIsIndexLoading(true);
+    setIndexError(null);
+
+    void loadConstituencyBoundariesIndex(manifest)
+      .then((payload) => {
+        if (!active) {
+          return;
+        }
+
+        setBoundaryIndex(payload);
+      })
+      .catch((error: Error) => {
+        if (!active) {
+          return;
+        }
+
+        setIndexError(error.message);
+        setBoundaryIndex(null);
+      })
+      .finally(() => {
+        if (!active) {
+          return;
+        }
+
+        setIsIndexLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [manifest]);
+
+  useEffect(() => {
+    if (!boundaryIndex || boundaryIndex.provinces.length === 0) {
+      return;
+    }
+
+    const fallbackProvince =
+      preferredProvince?.provinceShortName ?? boundaryIndex.provinces[0]?.provinceShortName ?? null;
+
+    if (!fallbackProvince) {
+      return;
+    }
+
+    setActiveProvinceShortName((current) =>
+      current === fallbackProvince ? current : fallbackProvince
+    );
+  }, [boundaryIndex, preferredProvince?.provinceShortName]);
+
+  useEffect(() => {
+    if (!activeProvince || provinceTopologies[activeProvince.provinceShortName] !== undefined) {
+      return;
+    }
+
+    let active = true;
+    setIsProvinceLoading(true);
+    setProvinceError(null);
+
+    void loadConstituencyProvinceTopology<ConstituencyBoundaryTopology>(activeProvince.path)
+      .then((payload) => {
+        if (!active) {
+          return;
+        }
+
+        setProvinceTopologies((current) => ({
+          ...current,
+          [activeProvince.provinceShortName]: payload
+        }));
+      })
+      .catch((error: Error) => {
+        if (!active) {
+          return;
+        }
+
+        setProvinceError(error.message);
+        setProvinceTopologies((current) => ({
+          ...current,
+          [activeProvince.provinceShortName]: null
+        }));
+      })
+      .finally(() => {
+        if (!active) {
+          return;
+        }
+
+        setIsProvinceLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [activeProvince, provinceTopologies]);
+
+  const regions = useMemo(
+    () =>
+      activeTopology
+        ? buildConstituencyMapRegions({
+            topology: activeTopology,
+            members,
+            highlightedMemberIds,
+            width: MAP_WIDTH,
+            height: MAP_HEIGHT
+          })
+        : [],
+    [activeTopology, highlightedMemberIds, members]
+  );
+
+  const matchedRegions = useMemo(
+    () => regions.filter((region) => region.member),
+    [regions]
+  );
+  const highlightedRegions = useMemo(
+    () => matchedRegions.filter((region) => region.highlighted),
+    [matchedRegions]
+  );
+  const selectedMemberRegion = useMemo(
+    () => regions.find((region) => region.member?.memberId === selectedMemberId) ?? null,
+    [regions, selectedMemberId]
+  );
+  const selectedRegion =
+    regions.find((region) => region.districtKey === selectedDistrictKey) ??
+    selectedMemberRegion ??
+    highlightedRegions[0] ??
+    matchedRegions[0] ??
+    regions[0] ??
+    null;
+
+  useEffect(() => {
+    if (!selectedRegion || selectedRegion.districtKey === selectedDistrictKey) {
+      return;
+    }
+
+    setSelectedDistrictKey(selectedRegion.districtKey);
+  }, [selectedDistrictKey, selectedRegion]);
+
+  const provinceAttendanceAverage =
+    highlightedRegions.length > 0
+      ? highlightedRegions.reduce(
+          (sum, region) => sum + (region.member?.attendanceRate ?? 0),
+          0
+        ) / highlightedRegions.length
+      : 0;
+  const provinceAbsenceAverage =
+    highlightedRegions.length > 0
+      ? highlightedRegions.reduce((sum, region) => sum + (region.member?.absentRate ?? 0), 0) /
+        highlightedRegions.length
+      : 0;
+  const activeMetricMeta = getActiveMetricMeta(metricMode);
+
+  function handleSelectProvince(provinceShortName: string) {
+    setActiveProvinceShortName(provinceShortName);
+    setSelectedDistrictKey(null);
+  }
+
+  function handleSelectRegion(region: ConstituencyMapRegion) {
+    setSelectedDistrictKey(region.districtKey);
+
+    if (region.member) {
+      onSelectMember(region.member.memberId);
+    }
+  }
+
+  if (isIndexLoading && !boundaryIndex && !indexError) {
+    return (
+      <section className="distribution-map" aria-live="polite">
+        <p className="section-label">지역구 지도</p>
+        <h2>지역구 boundary를 불러오는 중입니다.</h2>
+        <p className="distribution-page__search-note">
+          manifest와 province shard를 확인한 뒤 지도 패널을 엽니다.
+        </p>
+      </section>
+    );
+  }
+
+  if (indexError) {
+    return (
+      <section className="distribution-map distribution-map--error" aria-live="polite">
+        <p className="section-label">지역구 지도</p>
+        <h2>지도 데이터를 열 수 없습니다.</h2>
+        <p className="distribution-page__search-note">{indexError}</p>
+      </section>
+    );
+  }
+
+  if (!boundaryIndex) {
+    return (
+      <section className="distribution-map distribution-map--error" aria-live="polite">
+        <p className="section-label">지역구 지도</p>
+        <h2>배포 데이터에 지역구 boundary export가 아직 없습니다.</h2>
+        <p className="distribution-page__search-note">
+          `exports/constituency_boundaries/index.json`이 발행되면 같은 distribution route 안에서 상세 지도를 바로 열 수 있습니다.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="distribution-map" aria-label="지역구 지도 패널">
+      <div className="distribution-map__header">
+        <div>
+          <p className="section-label">지역구 지도</p>
+          <h2>{`${activeProvince?.provinceShortName ?? "선택한"} 지역구별 핵심 통계`}</h2>
+          <p className="distribution-page__search-note">
+            지도에서 선거구를 누르면 대표 의원과 출석, 불참, 반대·기권 패턴을 같은 화면에서 확인할 수 있습니다.
+          </p>
+        </div>
+        <div className="distribution-map__summary-grid" aria-label="지역구 지도 요약">
+          <article className="chart-card__summary">
+            <span>매칭 지역구</span>
+            <strong>{`${formatNumber(matchedRegions.length)} / ${formatNumber(regions.length)}`}</strong>
+            <small>boundary 대비 current member 연결 수</small>
+          </article>
+          <article className="chart-card__summary">
+            <span>평균 출석률</span>
+            <strong>{formatPercent(provinceAttendanceAverage)}</strong>
+            <small>현재 강조 cohort 기준</small>
+          </article>
+          <article className="chart-card__summary">
+            <span>평균 불참 비중</span>
+            <strong>{formatPercent(provinceAbsenceAverage)}</strong>
+            <small>현재 강조 cohort 기준</small>
+          </article>
+        </div>
+      </div>
+
+      <div className="distribution-map__controls">
+        <div className="distribution-map__province-list" role="tablist" aria-label="province 선택">
+          {boundaryIndex.provinces.map((province) => (
+            <button
+              key={province.provinceShortName}
+              type="button"
+              className={
+                province.provinceShortName === activeProvinceShortName
+                  ? "distribution-map__province-button is-active"
+                  : "distribution-map__province-button"
+              }
+              aria-selected={province.provinceShortName === activeProvinceShortName}
+              onClick={() => handleSelectProvince(province.provinceShortName)}
+            >
+              <span>{province.provinceShortName}</span>
+              <strong>{`${formatNumber(province.featureCount)}곳`}</strong>
+            </button>
+          ))}
+        </div>
+        <div className="distribution-map__metric-list" aria-label="지도 색상 기준">
+          {METRIC_OPTIONS.map((metric) => (
+            <button
+              key={metric.key}
+              type="button"
+              className={
+                metric.key === metricMode
+                  ? "distribution-map__metric-button is-active"
+                  : "distribution-map__metric-button"
+              }
+              aria-pressed={metric.key === metricMode}
+              onClick={() => setMetricMode(metric.key)}
+            >
+              {metric.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="distribution-map__legend">
+        <div className="distribution-map__legend-scale" aria-hidden="true">
+          <span />
+          <span />
+        </div>
+        <p className="distribution-page__search-note">{activeMetricMeta.description}</p>
+        <p className="distribution-page__search-note">
+          {buildRegionScopeText({
+            matchedRegions,
+            highlightedRegions,
+            totalRegions: regions.length
+          })}
+        </p>
+      </div>
+
+      <div className="distribution-map__layout">
+        <div className="distribution-map__surface">
+          {isProvinceLoading && activeTopology === undefined ? (
+            <div className="distribution-map__state">
+              <h3>{`${activeProvince?.provinceShortName ?? "선택한 province"} 지도를 불러오는 중입니다.`}</h3>
+              <p className="distribution-page__search-note">
+                province shard를 받은 뒤 지역구별 SVG 경계를 그립니다.
+              </p>
+            </div>
+          ) : provinceError ? (
+            <div className="distribution-map__state">
+              <h3>province shard를 열 수 없습니다.</h3>
+              <p className="distribution-page__search-note">{provinceError}</p>
+            </div>
+          ) : activeTopology === null ? (
+            <div className="distribution-map__state">
+              <h3>선택한 province shard가 아직 발행되지 않았습니다.</h3>
+              <p className="distribution-page__search-note">
+                boundary index는 보이지만 실제 지도 파일이 없어 로컬 기준으로만 준비된 상태입니다.
+              </p>
+            </div>
+          ) : (
+            <svg
+              className="distribution-map__svg"
+              viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
+              role="img"
+              aria-label={`${activeProvince?.provinceShortName ?? "선택한 province"} 지역구 지도`}
+            >
+              {regions.map((region) => {
+                const isSelected = selectedRegion?.districtKey === region.districtKey;
+                return (
+                  <g
+                    key={region.districtKey}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={region.properties.memberDistrictLabel}
+                    onClick={() => handleSelectRegion(region)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        handleSelectRegion(region);
+                      }
+                    }}
+                  >
+                    <title>{region.properties.memberDistrictLabel}</title>
+                    <path
+                      d={region.path}
+                      className={
+                        isSelected
+                          ? "distribution-map__region is-selected"
+                          : "distribution-map__region"
+                      }
+                      fill={getRegionFill(region, metricMode)}
+                    />
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+        </div>
+
+        <DistributionConstituencyMapDetail
+          region={selectedRegion}
+          selectedMemberId={selectedMemberId}
+          onSelectMember={onSelectMember}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/DistributionPage.tsx
+++ b/apps/web/src/components/DistributionPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import type {
   AccountabilitySummaryExport,
+  Manifest,
   MemberActivityCalendarExport
 } from "@lawmaker-monitor/schemas";
 import {
@@ -29,12 +30,14 @@ import {
 } from "../lib/distribution.js";
 import { formatNumber, formatPercent } from "../lib/format.js";
 import { getOptimizedMemberPhotoUrl } from "../lib/member-photo.js";
+import { DistributionConstituencyMap } from "./DistributionConstituencyMap.js";
 import { MemberIdentity } from "./MemberIdentity.js";
 import { MemberSearchField } from "./MemberSearchField.js";
 
 type DistributionPageProps = {
   accountabilitySummary: AccountabilitySummaryExport | null;
   activityCalendar: MemberActivityCalendarExport | null;
+  manifest: Manifest | null;
   loading: boolean;
   errors: string[];
   assemblyLabel: string;
@@ -350,6 +353,7 @@ function DistributionSignalList({
 export function DistributionPage({
   accountabilitySummary,
   activityCalendar,
+  manifest,
   loading,
   errors,
   assemblyLabel,
@@ -432,6 +436,10 @@ export function DistributionPage({
   const otherChartPoints = filteredChartPoints.filter((member) => member.memberId !== selectedMemberId);
   const activePartySummary =
     partySummaries.find((summary) => summary.party === activePartyFilter) ?? null;
+  const highlightedMemberIds = useMemo(
+    () => new Set(filteredMembers.map((member) => member.memberId)),
+    [filteredMembers]
+  );
 
   const averageAttendanceRate =
     behaviorFilteredMembers.length > 0
@@ -621,174 +629,184 @@ export function DistributionPage({
       </section>
 
       <div className="distribution-page__layout">
-        <section className="distribution-chart" aria-label="의원 분포 차트">
-          <div className="distribution-chart__header">
-            <div>
-              <div className="distribution-chart__eyebrow">
-                <p className="section-label">좌표 분포</p>
-                <button
-                  type="button"
-                  className="distribution-chart__help-button"
-                  aria-label={isChartHelpOpen ? "분포 설명 닫기" : "분포 설명 보기"}
-                  aria-expanded={isChartHelpOpen}
-                  aria-controls="distribution-chart-help"
-                  onClick={() => setIsChartHelpOpen((current) => !current)}
-                >
-                  ?
-                </button>
-              </div>
-              <h2>{chartHeading}</h2>
-              {activeBehaviorSummary ? (
-                <div className="distribution-chart__filter-row">
-                  <p className="distribution-page__search-note">
-                    {`${activeBehaviorSummary.description}. 현재 ${formatNumber(behaviorFilteredMembers.length)}명을 같은 기준으로 묶었습니다.`}
-                  </p>
+        <div className="distribution-page__main-column">
+          <DistributionConstituencyMap
+            manifest={manifest}
+            members={members}
+            highlightedMemberIds={highlightedMemberIds}
+            selectedMemberId={selectedMemberId}
+            onSelectMember={handleSelectMember}
+          />
+
+          <section className="distribution-chart" aria-label="의원 분포 차트">
+            <div className="distribution-chart__header">
+              <div>
+                <div className="distribution-chart__eyebrow">
+                  <p className="section-label">좌표 분포</p>
                   <button
                     type="button"
-                    className="distribution-chart__filter-pill"
-                    onClick={handleClearBehaviorFilter}
-                    aria-label={`행동 분류 ${activeBehaviorSummary.label} 해제`}
+                    className="distribution-chart__help-button"
+                    aria-label={isChartHelpOpen ? "분포 설명 닫기" : "분포 설명 보기"}
+                    aria-expanded={isChartHelpOpen}
+                    aria-controls="distribution-chart-help"
+                    onClick={() => setIsChartHelpOpen((current) => !current)}
                   >
-                    <span>행동 분류</span>
-                    <strong>{activeBehaviorSummary.label}</strong>
-                    <small>{`${formatNumber(behaviorFilteredMembers.length)}명`}</small>
+                    ?
                   </button>
                 </div>
-              ) : null}
-              {isChartHelpOpen ? (
-                <div id="distribution-chart-help" className="distribution-chart__help-panel" role="note">
-                  <p className="distribution-page__copy">
-                    출석률과 반대·기권 비중을 한 좌표에 두고, 불참과 연속 패턴을 함께 읽는 첫 분포 화면입니다.
-                  </p>
-                  <p className="distribution-chart__copy">
-                    가로축은 출석률, 세로축은 반대·기권 비중이며 값이 낮을수록 위로 올라갑니다. 점 크기는 현재 반대·기권·불참 연속 패턴을 반영합니다.
-                  </p>
-                  <p className="distribution-page__search-note">{chartSearchNote}</p>
+                <h2>{chartHeading}</h2>
+                {activeBehaviorSummary ? (
+                  <div className="distribution-chart__filter-row">
+                    <p className="distribution-page__search-note">
+                      {`${activeBehaviorSummary.description}. 현재 ${formatNumber(behaviorFilteredMembers.length)}명을 같은 기준으로 묶었습니다.`}
+                    </p>
+                    <button
+                      type="button"
+                      className="distribution-chart__filter-pill"
+                      onClick={handleClearBehaviorFilter}
+                      aria-label={`행동 분류 ${activeBehaviorSummary.label} 해제`}
+                    >
+                      <span>행동 분류</span>
+                      <strong>{activeBehaviorSummary.label}</strong>
+                      <small>{`${formatNumber(behaviorFilteredMembers.length)}명`}</small>
+                    </button>
+                  </div>
+                ) : null}
+                {isChartHelpOpen ? (
+                  <div id="distribution-chart-help" className="distribution-chart__help-panel" role="note">
+                    <p className="distribution-page__copy">
+                      출석률과 반대·기권 비중을 한 좌표에 두고, 불참과 연속 패턴을 함께 읽는 첫 분포 화면입니다.
+                    </p>
+                    <p className="distribution-chart__copy">
+                      가로축은 출석률, 세로축은 반대·기권 비중이며 값이 낮을수록 위로 올라갑니다. 점 크기는 현재 반대·기권·불참 연속 패턴을 반영합니다.
+                    </p>
+                    <p className="distribution-page__search-note">{chartSearchNote}</p>
+                  </div>
+                ) : null}
+              </div>
+              <div className="distribution-chart__summary-grid" aria-label="분포 요약">
+                <div className="chart-card__summary">
+                  <span>대상 의원</span>
+                  <strong>{`${formatNumber(filteredMembers.length)}명`}</strong>
+                  <small>{filterScopeText}</small>
                 </div>
-              ) : null}
-            </div>
-            <div className="distribution-chart__summary-grid" aria-label="분포 요약">
-              <div className="chart-card__summary">
-                <span>대상 의원</span>
-                <strong>{`${formatNumber(filteredMembers.length)}명`}</strong>
-                <small>{filterScopeText}</small>
-              </div>
-              <div className="chart-card__summary">
-                <span>평균 출석률</span>
-                <strong>{formatPercent(averageAttendanceRate)}</strong>
-                <small>캘린더 날짜 기준</small>
-              </div>
-              <div className="chart-card__summary">
-                <span>평균 반대·기권 비중</span>
-                <strong>{formatPercent(averageNegativeRate)}</strong>
-                <small>
-                  {activeBehaviorSummary
-                    ? "행동 분류 기준"
-                    : activePartySummary
-                    ? `${activePartySummary.party} 필터 적용 중`
-                    : "기록표결 분모 기준"}
-                </small>
+                <div className="chart-card__summary">
+                  <span>평균 출석률</span>
+                  <strong>{formatPercent(averageAttendanceRate)}</strong>
+                  <small>캘린더 날짜 기준</small>
+                </div>
+                <div className="chart-card__summary">
+                  <span>평균 반대·기권 비중</span>
+                  <strong>{formatPercent(averageNegativeRate)}</strong>
+                  <small>
+                    {activeBehaviorSummary
+                      ? "행동 분류 기준"
+                      : activePartySummary
+                      ? `${activePartySummary.party} 필터 적용 중`
+                      : "기록표결 분모 기준"}
+                  </small>
+                </div>
               </div>
             </div>
-          </div>
-          <div className="distribution-chart__surface">
-            <ResponsiveContainer width="100%" height={420}>
-              <ScatterChart margin={{ top: 22, right: 28, bottom: 34, left: 12 }}>
-                <CartesianGrid stroke="rgba(72, 56, 40, 0.12)" />
-                <ReferenceLine
-                  x={Number((averageAttendanceRate * 100).toFixed(1))}
-                  stroke="rgba(123, 49, 40, 0.22)"
-                  strokeDasharray="4 4"
-                />
-                <ReferenceLine
-                  y={Number((averageNegativeRate * 100).toFixed(1))}
-                  stroke="rgba(123, 49, 40, 0.22)"
-                  strokeDasharray="4 4"
-                />
-                <XAxis
-                  type="number"
-                  dataKey="attendancePercent"
-                  domain={attendanceDomain}
-                  tick={{ fill: "rgba(29, 24, 18, 0.72)", fontSize: 12 }}
-                  tickFormatter={(value) => `${value}%`}
-                  label={{ value: "출석률", position: "insideBottom", offset: -12 }}
-                />
-                <YAxis
-                  type="number"
-                  dataKey="negativePercent"
-                  domain={negativeDomain}
-                  reversed
-                  tick={{ fill: "rgba(29, 24, 18, 0.72)", fontSize: 12 }}
-                  tickFormatter={(value) => `${value}%`}
-                  width={44}
-                  label={{ value: "반대·기권 비중", angle: -90, position: "insideLeft" }}
-                />
-                <Tooltip content={<DistributionTooltipPanel />} />
-                <Scatter
-                  data={otherChartPoints}
-                  shape={(props) => (
-                    <DistributionPointShape
-                      {...props}
-                      partyColors={partyColors}
-                      onSelectMember={handleSelectMember}
-                      showPhoto={!activePartyFilter}
-                    />
-                  )}
-                />
-                {selectedChartPoint ? (
+            <div className="distribution-chart__surface">
+              <ResponsiveContainer width="100%" height={420}>
+                <ScatterChart margin={{ top: 22, right: 28, bottom: 34, left: 12 }}>
+                  <CartesianGrid stroke="rgba(72, 56, 40, 0.12)" />
+                  <ReferenceLine
+                    x={Number((averageAttendanceRate * 100).toFixed(1))}
+                    stroke="rgba(123, 49, 40, 0.22)"
+                    strokeDasharray="4 4"
+                  />
+                  <ReferenceLine
+                    y={Number((averageNegativeRate * 100).toFixed(1))}
+                    stroke="rgba(123, 49, 40, 0.22)"
+                    strokeDasharray="4 4"
+                  />
+                  <XAxis
+                    type="number"
+                    dataKey="attendancePercent"
+                    domain={attendanceDomain}
+                    tick={{ fill: "rgba(29, 24, 18, 0.72)", fontSize: 12 }}
+                    tickFormatter={(value) => `${value}%`}
+                    label={{ value: "출석률", position: "insideBottom", offset: -12 }}
+                  />
+                  <YAxis
+                    type="number"
+                    dataKey="negativePercent"
+                    domain={negativeDomain}
+                    reversed
+                    tick={{ fill: "rgba(29, 24, 18, 0.72)", fontSize: 12 }}
+                    tickFormatter={(value) => `${value}%`}
+                    width={44}
+                    label={{ value: "반대·기권 비중", angle: -90, position: "insideLeft" }}
+                  />
+                  <Tooltip content={<DistributionTooltipPanel />} />
                   <Scatter
-                    data={[selectedChartPoint]}
+                    data={otherChartPoints}
                     shape={(props) => (
                       <DistributionPointShape
                         {...props}
-                        selected
                         partyColors={partyColors}
                         onSelectMember={handleSelectMember}
                         showPhoto={!activePartyFilter}
                       />
                     )}
                   />
-                ) : null}
-              </ScatterChart>
-            </ResponsiveContainer>
-          </div>
-          <div className="distribution-chart__legend">
-            <div className="distribution-chart__legend-copy">
-              <strong>정당 필터</strong>
-              <span>
-                {activePartySummary
-                  ? `${activePartySummary.party}만 ${formatNumber(filteredMembers.length)}명 표시 중입니다. 같은 정당을 다시 누르면 전체 보기로 돌아갑니다.`
-                  : "정당을 누르면 해당 정당만 남기고 점은 얼굴 대신 정당색으로 전환됩니다."}
-              </span>
+                  {selectedChartPoint ? (
+                    <Scatter
+                      data={[selectedChartPoint]}
+                      shape={(props) => (
+                        <DistributionPointShape
+                          {...props}
+                          selected
+                          partyColors={partyColors}
+                          onSelectMember={handleSelectMember}
+                          showPhoto={!activePartyFilter}
+                        />
+                      )}
+                    />
+                  ) : null}
+                </ScatterChart>
+              </ResponsiveContainer>
             </div>
-            <ul className="distribution-chart__legend-list" aria-label="정당 필터">
-              {partySummaries.map((summary) => (
-                <li key={summary.party}>
-                  <button
-                    type="button"
-                    className={
-                      summary.party === activePartyFilter
-                        ? "distribution-chart__legend-button is-active"
-                        : "distribution-chart__legend-button"
-                    }
-                    aria-pressed={summary.party === activePartyFilter}
-                    aria-label={
-                      summary.party === activePartyFilter
-                        ? `${summary.party} 필터 해제`
-                        : `${summary.party} 필터 적용`
-                    }
-                    onClick={() => handleTogglePartyFilter(summary.party)}
-                  >
-                    <i style={{ backgroundColor: partyColors.get(summary.party) ?? partyPalette[0] }} />
-                    <span>{summary.party}</span>
-                    <strong>{`${formatNumber(summary.memberCount)}명`}</strong>
-                    <small>{`평균 반대·기권 ${formatPercent(summary.averageNegativeRate)}`}</small>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
+            <div className="distribution-chart__legend">
+              <div className="distribution-chart__legend-copy">
+                <strong>정당 필터</strong>
+                <span>
+                  {activePartySummary
+                    ? `${activePartySummary.party}만 ${formatNumber(filteredMembers.length)}명 표시 중입니다. 같은 정당을 다시 누르면 전체 보기로 돌아갑니다.`
+                    : "정당을 누르면 해당 정당만 남기고 점은 얼굴 대신 정당색으로 전환됩니다."}
+                </span>
+              </div>
+              <ul className="distribution-chart__legend-list" aria-label="정당 필터">
+                {partySummaries.map((summary) => (
+                  <li key={summary.party}>
+                    <button
+                      type="button"
+                      className={
+                        summary.party === activePartyFilter
+                          ? "distribution-chart__legend-button is-active"
+                          : "distribution-chart__legend-button"
+                      }
+                      aria-pressed={summary.party === activePartyFilter}
+                      aria-label={
+                        summary.party === activePartyFilter
+                          ? `${summary.party} 필터 해제`
+                          : `${summary.party} 필터 적용`
+                      }
+                      onClick={() => handleTogglePartyFilter(summary.party)}
+                    >
+                      <i style={{ backgroundColor: partyColors.get(summary.party) ?? partyPalette[0] }} />
+                      <span>{summary.party}</span>
+                      <strong>{`${formatNumber(summary.memberCount)}명`}</strong>
+                      <small>{`평균 반대·기권 ${formatPercent(summary.averageNegativeRate)}`}</small>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        </div>
 
         {selectedMember ? (
           <aside className="distribution-focus" aria-label="선택 의원 요약">

--- a/apps/web/src/lib/constituency-map.ts
+++ b/apps/web/src/lib/constituency-map.ts
@@ -1,0 +1,260 @@
+import type {
+  ConstituencyBoundariesIndexProvince,
+  ConstituencyBoundaryProperties,
+  GeoJsonMultiPolygon,
+  GeoJsonPolygon
+} from "@lawmaker-monitor/schemas";
+import { feature } from "topojson-client";
+
+import type { DistributionMemberPoint } from "./distribution.js";
+
+export type ConstituencyMetricMode = "attendance" | "absent" | "negative";
+
+export type ConstituencyBoundaryTopology = {
+  type: "Topology";
+  objects: {
+    constituencies: {
+      type: "GeometryCollection";
+      geometries: Array<{
+        type: string;
+        properties: ConstituencyBoundaryProperties;
+        arcs: unknown;
+      }>;
+    };
+  };
+  arcs: unknown[];
+  bbox?: [number, number, number, number];
+  transform?: {
+    scale: [number, number];
+    translate: [number, number];
+  };
+};
+
+type ConstituencyFeature = {
+  type: "Feature";
+  properties: ConstituencyBoundaryProperties;
+  geometry: GeoJsonPolygon | GeoJsonMultiPolygon;
+};
+
+type ConstituencyFeatureCollection = {
+  type: "FeatureCollection";
+  features: ConstituencyFeature[];
+};
+
+type Point = [number, number];
+
+type Bounds = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+};
+
+export type ConstituencyMapRegion = {
+  districtKey: string;
+  properties: ConstituencyBoundaryProperties;
+  path: string;
+  member: DistributionMemberPoint | null;
+  highlighted: boolean;
+};
+
+const DEFAULT_MAP_WIDTH = 920;
+const DEFAULT_MAP_HEIGHT = 760;
+const DEFAULT_MAP_PADDING = 28;
+
+export function normalizeConstituencyLookupKey(value: string | null | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  return value.replace(/\s+/g, "").replace(/[ㆍ?]/g, "·").trim();
+}
+
+export function resolveProvinceForDistrict(
+  district: string | null | undefined,
+  provinces: ConstituencyBoundariesIndexProvince[]
+): ConstituencyBoundariesIndexProvince | null {
+  const normalizedDistrict = normalizeConstituencyLookupKey(district);
+  if (!normalizedDistrict) {
+    return null;
+  }
+
+  return (
+    provinces.find((province) => {
+      const shortName = normalizeConstituencyLookupKey(province.provinceShortName);
+      const fullName = normalizeConstituencyLookupKey(province.provinceName);
+      return normalizedDistrict.startsWith(shortName) || normalizedDistrict.startsWith(fullName);
+    }) ?? null
+  );
+}
+
+export function getConstituencyMetricValue(
+  member: DistributionMemberPoint,
+  metricMode: ConstituencyMetricMode
+): number {
+  if (metricMode === "attendance") {
+    return member.attendanceRate;
+  }
+
+  if (metricMode === "absent") {
+    return member.absentRate;
+  }
+
+  return member.negativeRate;
+}
+
+function buildFeatureLookupKeys(properties: ConstituencyBoundaryProperties): string[] {
+  return [
+    properties.memberDistrictLabel,
+    properties.memberDistrictKey,
+    properties.districtName,
+    properties.lawDistrictName,
+    ...properties.aliases
+  ]
+    .map((candidate) => normalizeConstituencyLookupKey(candidate))
+    .filter((candidate, index, array) => candidate.length > 0 && array.indexOf(candidate) === index);
+}
+
+function buildMemberLookupMap(members: DistributionMemberPoint[]): Map<string, DistributionMemberPoint | null> {
+  const memberByKey = new Map<string, DistributionMemberPoint | null>();
+
+  for (const member of members) {
+    const lookupKey = normalizeConstituencyLookupKey(member.district);
+    if (!lookupKey) {
+      continue;
+    }
+
+    const existing = memberByKey.get(lookupKey);
+    memberByKey.set(lookupKey, existing && existing.memberId !== member.memberId ? null : member);
+  }
+
+  return memberByKey;
+}
+
+function topologyToFeatures(topology: ConstituencyBoundaryTopology): ConstituencyFeature[] {
+  const collection = feature(
+    topology,
+    topology.objects.constituencies
+  ) as ConstituencyFeatureCollection;
+
+  return collection.features;
+}
+
+function readBounds(features: ConstituencyFeature[]): Bounds {
+  let minX = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const feature of features) {
+    const polygons =
+      feature.geometry.type === "Polygon"
+        ? [feature.geometry.coordinates]
+        : feature.geometry.coordinates;
+
+    for (const polygon of polygons) {
+      for (const ring of polygon) {
+        for (const [x, y] of ring) {
+          minX = Math.min(minX, x);
+          maxX = Math.max(maxX, x);
+          minY = Math.min(minY, y);
+          maxY = Math.max(maxY, y);
+        }
+      }
+    }
+  }
+
+  if (!Number.isFinite(minX) || !Number.isFinite(maxX) || !Number.isFinite(minY) || !Number.isFinite(maxY)) {
+    return {
+      minX: 0,
+      maxX: 1,
+      minY: 0,
+      maxY: 1
+    };
+  }
+
+  return {
+    minX,
+    maxX,
+    minY,
+    maxY
+  };
+}
+
+function buildProjector(bounds: Bounds, width: number, height: number, padding: number) {
+  const spanX = Math.max(bounds.maxX - bounds.minX, 1);
+  const spanY = Math.max(bounds.maxY - bounds.minY, 1);
+  const usableWidth = Math.max(width - padding * 2, 1);
+  const usableHeight = Math.max(height - padding * 2, 1);
+  const scale = Math.min(usableWidth / spanX, usableHeight / spanY);
+  const contentWidth = spanX * scale;
+  const contentHeight = spanY * scale;
+  const offsetX = padding + (usableWidth - contentWidth) / 2 - bounds.minX * scale;
+  const offsetY = padding + (usableHeight - contentHeight) / 2 + bounds.maxY * scale;
+
+  return ([x, y]: Point): Point => [x * scale + offsetX, offsetY - y * scale];
+}
+
+function buildRingPath(ring: Point[], project: (point: Point) => Point): string {
+  return ring
+    .map((point, index) => {
+      const [x, y] = project(point);
+      const command = index === 0 ? "M" : "L";
+      return `${command}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ")
+    .concat(" Z");
+}
+
+function buildFeaturePath(
+  geometry: GeoJsonPolygon | GeoJsonMultiPolygon,
+  project: (point: Point) => Point
+): string {
+  if (geometry.type === "Polygon") {
+    return geometry.coordinates.map((ring) => buildRingPath(ring, project)).join(" ");
+  }
+
+  return geometry.coordinates
+    .map((polygon) => polygon.map((ring) => buildRingPath(ring, project)).join(" "))
+    .join(" ");
+}
+
+export function buildConstituencyMapRegions(args: {
+  topology: ConstituencyBoundaryTopology;
+  members: DistributionMemberPoint[];
+  highlightedMemberIds?: ReadonlySet<string>;
+  width?: number;
+  height?: number;
+  padding?: number;
+}): ConstituencyMapRegion[] {
+  const features = topologyToFeatures(args.topology);
+  const bounds = readBounds(features);
+  const project = buildProjector(
+    bounds,
+    args.width ?? DEFAULT_MAP_WIDTH,
+    args.height ?? DEFAULT_MAP_HEIGHT,
+    args.padding ?? DEFAULT_MAP_PADDING
+  );
+  const memberByKey = buildMemberLookupMap(args.members);
+
+  return features
+    .map((currentFeature) => {
+      const matchingMember =
+        buildFeatureLookupKeys(currentFeature.properties)
+          .map((lookupKey) => memberByKey.get(lookupKey) ?? null)
+          .find((member): member is DistributionMemberPoint => Boolean(member)) ?? null;
+
+      return {
+        districtKey: currentFeature.properties.memberDistrictKey,
+        properties: currentFeature.properties,
+        path: buildFeaturePath(currentFeature.geometry, project),
+        member: matchingMember,
+        highlighted: matchingMember
+          ? args.highlightedMemberIds?.has(matchingMember.memberId) ?? true
+          : false
+      };
+    })
+    .sort((left, right) =>
+      left.properties.memberDistrictLabel.localeCompare(right.properties.memberDistrictLabel, "ko")
+    );
+}

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -1,6 +1,7 @@
 import type {
   AccountabilitySummaryExport,
   AccountabilityTrendsExport,
+  ConstituencyBoundariesIndexExport,
   LatestVotesExport,
   MemberActivityCalendarExport,
   MemberActivityCalendarMemberDetailExport,
@@ -9,6 +10,7 @@ import type {
 import {
   accountabilitySummaryExportSchema,
   accountabilityTrendsExportSchema,
+  constituencyBoundariesIndexExportSchema,
   latestVotesExportSchema,
   memberActivityCalendarExportSchema,
   memberActivityCalendarMemberDetailExportSchema,
@@ -89,6 +91,22 @@ export function loadMemberActivityCalendarMemberDetail(
   return fetchOptionalJson(buildUrl(path), (payload) =>
     memberActivityCalendarMemberDetailExportSchema.parse(payload)
   );
+}
+
+export function loadConstituencyBoundariesIndex(
+  manifest?: Manifest | null
+): Promise<ConstituencyBoundariesIndexExport | null> {
+  const indexPath =
+    manifest?.exports.constituencyBoundariesIndex?.path ??
+    "exports/constituency_boundaries/index.json";
+
+  return fetchOptionalJson(buildUrl(indexPath), (payload) =>
+    constituencyBoundariesIndexExportSchema.parse(payload)
+  );
+}
+
+export function loadConstituencyProvinceTopology<T>(path: string): Promise<T | null> {
+  return fetchOptionalJson(buildUrl(path), (payload) => payload as T);
 }
 
 export function getDataRepoBaseUrl(): string {

--- a/apps/web/src/styles/distribution-refresh.css
+++ b/apps/web/src/styles/distribution-refresh.css
@@ -1,4 +1,5 @@
 .distribution-page__masthead,
+.distribution-map,
 .distribution-chart,
 .distribution-focus,
 .distribution-signal-card,
@@ -14,9 +15,20 @@
 
 .distribution-page__masthead,
 .distribution-page__layout,
+.distribution-page__main-column,
 .distribution-signal-grid,
 .distribution-page__headline,
 .distribution-page__search,
+.distribution-map,
+.distribution-map__header,
+.distribution-map__controls,
+.distribution-map__province-list,
+.distribution-map__metric-list,
+.distribution-map__legend,
+.distribution-map__layout,
+.distribution-map__detail-actions,
+.distribution-map__detail-metrics,
+.distribution-map__detail-facts,
 .distribution-chart__header,
 .distribution-chart__legend,
 .distribution-focus__header,
@@ -32,6 +44,7 @@
 }
 
 .distribution-page__masthead::before,
+.distribution-map::before,
 .distribution-chart::before,
 .distribution-focus::before,
 .distribution-signal-card::before,
@@ -97,6 +110,10 @@
   align-items: start;
 }
 
+.distribution-page__main-column {
+  min-width: 0;
+}
+
 .distribution-chart__eyebrow {
   display: flex;
   align-items: center;
@@ -109,12 +126,206 @@
   align-items: start;
 }
 
+.distribution-map h2,
 .distribution-chart h2,
+.distribution-map__detail h3,
 .distribution-signal-card h3 {
   margin: 0.1rem 0 0;
   font-size: clamp(1.18rem, 2.1vw, 1.52rem);
   line-height: 1.18;
   word-break: keep-all;
+}
+
+.distribution-map__summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.72rem;
+}
+
+.distribution-map__controls {
+  gap: 0.72rem;
+}
+
+.distribution-map__province-list,
+.distribution-map__metric-list {
+  grid-template-columns: repeat(auto-fit, minmax(5.5rem, max-content));
+  align-items: start;
+}
+
+.distribution-map__province-button,
+.distribution-map__metric-button,
+.distribution-map__detail-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 2.75rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid rgba(72, 56, 40, 0.12);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--accent-strong);
+}
+
+.distribution-map__province-button,
+.distribution-map__metric-button {
+  justify-content: space-between;
+}
+
+.distribution-map__province-button.is-active,
+.distribution-map__metric-button.is-active,
+.distribution-map__detail-action:not(:disabled) {
+  border-color: rgba(123, 49, 40, 0.24);
+  box-shadow: 0 14px 28px rgba(123, 49, 40, 0.14);
+}
+
+.distribution-map__province-button.is-active,
+.distribution-map__metric-button.is-active {
+  background: linear-gradient(135deg, rgba(123, 49, 40, 0.14), rgba(255, 255, 255, 0.94));
+}
+
+.distribution-map__province-button strong {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.distribution-map__legend {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem 0.85rem;
+}
+
+.distribution-map__legend-scale {
+  width: 8.5rem;
+  height: 0.88rem;
+  border-radius: 999px;
+  border: 1px solid rgba(72, 56, 40, 0.1);
+  background: linear-gradient(90deg, #f6e8d5, var(--accent-strong));
+}
+
+.distribution-map__legend-scale span {
+  display: none;
+}
+
+.distribution-map__layout {
+  grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.92fr);
+  align-items: start;
+}
+
+.distribution-map__surface,
+.distribution-map__detail,
+.distribution-map__state {
+  border: 1px solid rgba(72, 56, 40, 0.1);
+  border-radius: 22px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(249, 245, 239, 0.94));
+}
+
+.distribution-map__surface {
+  min-height: 32rem;
+  padding: 0.95rem;
+}
+
+.distribution-map__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.distribution-map__region {
+  stroke: rgba(72, 56, 40, 0.24);
+  stroke-width: 1.4;
+  transition:
+    fill 180ms ease,
+    stroke 180ms ease,
+    stroke-width 180ms ease,
+    filter 180ms ease;
+}
+
+.distribution-map__region:hover,
+.distribution-map__region:focus-visible {
+  stroke: rgba(29, 24, 18, 0.64);
+  stroke-width: 2.2;
+  filter: saturate(1.05);
+}
+
+.distribution-map__region.is-selected {
+  stroke: rgba(29, 24, 18, 0.94);
+  stroke-width: 3;
+  filter: drop-shadow(0 8px 18px rgba(72, 56, 40, 0.18));
+}
+
+.distribution-map__detail,
+.distribution-map__state {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.distribution-map__detail-area {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.distribution-map__detail-actions {
+  margin-top: -0.1rem;
+}
+
+.distribution-map__detail-action:disabled {
+  color: var(--text-muted);
+  opacity: 0.9;
+  cursor: default;
+}
+
+.distribution-map__detail-metrics {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.distribution-map__detail-metrics article {
+  display: grid;
+  gap: 0.16rem;
+  padding: 0.82rem 0.88rem;
+  border: 1px solid rgba(72, 56, 40, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.distribution-map__detail-metrics span,
+.distribution-map__detail-facts dt {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.distribution-map__detail-metrics strong {
+  font-size: 1.15rem;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.distribution-map__detail-facts {
+  margin: 0;
+}
+
+.distribution-map__detail-facts > div {
+  display: grid;
+  gap: 0.12rem;
+  padding-top: 0.72rem;
+  border-top: 1px solid rgba(72, 56, 40, 0.1);
+}
+
+.distribution-map__detail-facts > div:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.distribution-map__detail-facts dd {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.55;
 }
 
 .distribution-chart__filter-row {
@@ -542,6 +753,7 @@
 @media (max-width: 1080px) {
   .distribution-page__masthead,
   .distribution-page__layout,
+  .distribution-map__layout,
   .distribution-chart__header,
   .distribution-chart__legend,
   .distribution-signal-grid {
@@ -551,6 +763,7 @@
 
 @media (max-width: 760px) {
   .distribution-page__masthead,
+  .distribution-map,
   .distribution-chart,
   .distribution-focus,
   .distribution-signal-card,
@@ -569,6 +782,13 @@
     border-radius: 18px;
   }
 
+  .distribution-map__surface,
+  .distribution-map__detail,
+  .distribution-map__state {
+    padding: 0.8rem;
+    border-radius: 18px;
+  }
+
   .distribution-chart__help-button {
     width: 2.75rem;
     height: 2.75rem;
@@ -576,6 +796,7 @@
     min-height: 2.75rem;
   }
 
+  .distribution-map__detail-metrics,
   .distribution-focus__metric-grid,
   .distribution-focus__composition-list,
   .distribution-party-list__stats {

--- a/apps/web/src/topojson-client.d.ts
+++ b/apps/web/src/topojson-client.d.ts
@@ -1,0 +1,3 @@
+declare module "topojson-client" {
+  export function feature(topology: unknown, object: unknown): unknown;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "html-to-image": "^1.11.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "recharts": "^3.8.0"
+        "recharts": "^3.8.0",
+        "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.24",

--- a/tests/web/app.test.tsx
+++ b/tests/web/app.test.tsx
@@ -17,7 +17,30 @@ const accountabilitySummaryFixture = JSON.parse(
 const accountabilityTrendsFixture = JSON.parse(
   readFileSync(resolve(fixturesDir, "accountability_trends.json"), "utf8")
 );
-const manifestFixture = JSON.parse(readFileSync(resolve(fixturesDir, "manifest.json"), "utf8"));
+const baseManifestFixture = JSON.parse(readFileSync(resolve(fixturesDir, "manifest.json"), "utf8"));
+const constituencyBoundariesIndexFixture = JSON.parse(
+  readFileSync(resolve(fixturesDir, "constituency_boundaries_index.json"), "utf8")
+);
+const constituencyProvinceFixtures = {
+  "부산": JSON.parse(
+    readFileSync(resolve(fixturesDir, "constituency_province_busan.topo.json"), "utf8")
+  ),
+  "서울": JSON.parse(
+    readFileSync(resolve(fixturesDir, "constituency_province_seoul.topo.json"), "utf8")
+  )
+};
+const manifestFixture = {
+  ...baseManifestFixture,
+  exports: {
+    ...baseManifestFixture.exports,
+    constituencyBoundariesIndex: {
+      path: "exports/constituency_boundaries/index.json",
+      url: "https://data.example.test/lawmaker-monitor/exports/constituency_boundaries/index.json",
+      checksumSha256: "constituency-index-checksum",
+      rowCount: 2
+    }
+  }
+};
 const memberActivityCalendarFixture = JSON.parse(
   readFileSync(resolve(fixturesDir, "member_activity_calendar.json"), "utf8")
 );
@@ -30,9 +53,9 @@ const memberActivityCalendarMemberDetailFixtures = {
   )
 };
 const legacyManifestFixture = {
-  ...manifestFixture,
+  ...baseManifestFixture,
   exports: {
-    latestVotes: manifestFixture.exports.latestVotes
+    latestVotes: baseManifestFixture.exports.latestVotes
   }
 };
 let fetchMock: ReturnType<typeof vi.fn>;
@@ -44,7 +67,8 @@ describe("web app", () => {
     window.location.hash = "";
     fetchMock = vi.fn((input: string | URL | Request) => {
       const url = String(input);
-      if (url.endsWith("/exports/latest_votes.json")) {
+      const decodedUrl = decodeURIComponent(url);
+      if (decodedUrl.endsWith("/exports/latest_votes.json")) {
         return Promise.resolve(
           new Response(JSON.stringify(latestVotesFixture), {
             status: 200,
@@ -53,7 +77,7 @@ describe("web app", () => {
         );
       }
 
-      if (url.endsWith("/exports/accountability_summary.json")) {
+      if (decodedUrl.endsWith("/exports/accountability_summary.json")) {
         return Promise.resolve(
           new Response(JSON.stringify(accountabilitySummaryFixture), {
             status: 200,
@@ -62,7 +86,7 @@ describe("web app", () => {
         );
       }
 
-      if (url.endsWith("/exports/accountability_trends.json")) {
+      if (decodedUrl.endsWith("/exports/accountability_trends.json")) {
         return Promise.resolve(
           new Response(JSON.stringify(accountabilityTrendsFixture), {
             status: 200,
@@ -71,7 +95,7 @@ describe("web app", () => {
         );
       }
 
-      if (url.endsWith("/exports/member_activity_calendar.json")) {
+      if (decodedUrl.endsWith("/exports/member_activity_calendar.json")) {
         return Promise.resolve(
           new Response(JSON.stringify(memberActivityCalendarFixture), {
             status: 200,
@@ -80,7 +104,7 @@ describe("web app", () => {
         );
       }
 
-      if (url.endsWith("/exports/member_activity_calendar_members/M001.json")) {
+      if (decodedUrl.endsWith("/exports/member_activity_calendar_members/M001.json")) {
         return Promise.resolve(
           new Response(JSON.stringify(memberActivityCalendarMemberDetailFixtures.M001), {
             status: 200,
@@ -89,7 +113,7 @@ describe("web app", () => {
         );
       }
 
-      if (url.endsWith("/exports/member_activity_calendar_members/M002.json")) {
+      if (decodedUrl.endsWith("/exports/member_activity_calendar_members/M002.json")) {
         return Promise.resolve(
           new Response(JSON.stringify(memberActivityCalendarMemberDetailFixtures.M002), {
             status: 200,
@@ -98,9 +122,36 @@ describe("web app", () => {
         );
       }
 
-      if (url.endsWith("/manifests/latest.json")) {
+      if (decodedUrl.endsWith("/manifests/latest.json")) {
         return Promise.resolve(
           new Response(JSON.stringify(manifestFixture), {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          })
+        );
+      }
+
+      if (decodedUrl.endsWith("/exports/constituency_boundaries/index.json")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(constituencyBoundariesIndexFixture), {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          })
+        );
+      }
+
+      if (decodedUrl.endsWith("/exports/constituency_boundaries/provinces/부산.topo.json")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(constituencyProvinceFixtures["부산"]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" }
+          })
+        );
+      }
+
+      if (decodedUrl.endsWith("/exports/constituency_boundaries/provinces/서울.topo.json")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(constituencyProvinceFixtures["서울"]), {
             status: 200,
             headers: { "Content-Type": "application/json" }
           })
@@ -219,12 +270,13 @@ describe("web app", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "제22대 국회 의원 분포" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "부산 지역구별 핵심 통계" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
         name: "위로 갈수록 반대·기권 비중이 낮고, 오른쪽으로 갈수록 출석률이 높습니다."
       })
     ).toBeInTheDocument();
-    expect(screen.getByText("부산 남구")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "부산 남구" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "분포에서 의원 찾기" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "활동 캘린더 열기" })).toHaveAttribute(
       "href",
@@ -234,6 +286,24 @@ describe("web app", () => {
     expect(
       screen.getByText("정당 평균을 눌러 차트를 해당 정당만 남기는 강조 모드로 전환합니다.")
     ).toBeInTheDocument();
+  });
+
+  it("switches province on the constituency map and links the chosen district back to distribution selection", async () => {
+    window.location.hash = "#distribution?member=M002";
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "부산 지역구별 핵심 통계" })).toBeInTheDocument();
+    const provinceTabs = screen.getByRole("tablist", { name: "province 선택" });
+    fireEvent.click(within(provinceTabs).getByRole("button", { name: /서울/ }));
+
+    expect(await screen.findByRole("heading", { name: "서울 지역구별 핵심 통계" })).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("서울 중구"));
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe("#distribution?member=M001");
+    });
+    expect(screen.getAllByText("김아라").length).toBeGreaterThan(0);
+    expect(screen.getByText("명동, 회현동")).toBeInTheDocument();
   });
 
   it("reveals the distribution help copy only when requested", async () => {

--- a/tests/web/constituency-map.test.tsx
+++ b/tests/web/constituency-map.test.tsx
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildConstituencyMapRegions,
+  resolveProvinceForDistrict
+} from "../../apps/web/src/lib/constituency-map.js";
+import { buildDistributionMembers } from "../../apps/web/src/lib/distribution.js";
+
+const fixturesDir = resolve(process.cwd(), "tests/fixtures/contracts");
+const accountabilitySummaryFixture = JSON.parse(
+  readFileSync(resolve(fixturesDir, "accountability_summary.json"), "utf8")
+);
+const memberActivityCalendarFixture = JSON.parse(
+  readFileSync(resolve(fixturesDir, "member_activity_calendar.json"), "utf8")
+);
+const constituencyBoundariesIndexFixture = JSON.parse(
+  readFileSync(resolve(fixturesDir, "constituency_boundaries_index.json"), "utf8")
+);
+const busanTopologyFixture = JSON.parse(
+  readFileSync(resolve(fixturesDir, "constituency_province_busan.topo.json"), "utf8")
+);
+
+describe("constituency map helpers", () => {
+  it("resolves a province shard from the current member district", () => {
+    expect(
+      resolveProvinceForDistrict("부산 남구", constituencyBoundariesIndexFixture.provinces)
+        ?.provinceShortName
+    ).toBe("부산");
+    expect(
+      resolveProvinceForDistrict("서울 중구", constituencyBoundariesIndexFixture.provinces)
+        ?.provinceShortName
+    ).toBe("서울");
+    expect(
+      resolveProvinceForDistrict("제주 제주시갑", constituencyBoundariesIndexFixture.provinces)
+    ).toBeNull();
+  });
+
+  it("matches district boundaries to member statistics and produces SVG paths", () => {
+    const members = buildDistributionMembers(
+      accountabilitySummaryFixture,
+      memberActivityCalendarFixture
+    );
+    const regions = buildConstituencyMapRegions({
+      topology: busanTopologyFixture,
+      members,
+      highlightedMemberIds: new Set(["M002"])
+    });
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]).toMatchObject({
+      districtKey: "부산남구",
+      highlighted: true,
+      properties: {
+        memberDistrictLabel: "부산 남구"
+      },
+      member: {
+        memberId: "M002",
+        district: "부산 남구"
+      }
+    });
+    expect(regions[0]?.path.startsWith("M")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- publish the NIT-326 constituency map panel through the main branch because github-pages rejects branch deploys outside the protected environment
- merge the candidate branch onto main and keep the active party summary copy from current main
- carry the constituency map panel, data wiring, styles, and web tests onto the deployable ref

## Validation
- npm run build --workspace @lawmaker-monitor/schemas
- npm run build --workspace @lawmaker-monitor/web
- npm test -- tests/web/app.test.tsx tests/web/constituency-map.test.tsx

## Evidence
- candidate branch: `nit-349-constituency-map-deploy-candidate` @ `8d9b98f0551c3103fe86480c05633ba854c37459`
- rejected branch deploy: https://github.com/kuil09/lawmaker-monitor/actions/runs/23702574117