### PR TITLE
[codex] NIT-356 simplify constituency map attendance view

### DIFF
--- a/apps/web/src/components/DistributionConstituencyMap.tsx
+++ b/apps/web/src/components/DistributionConstituencyMap.tsx
@@ -7,11 +7,11 @@ import type {
 
 import {
   buildConstituencyMapRegions,
-  getConstituencyMetricValue,
+  getConstituencyMetricColorIntensity,
+  getConstituencyMetricDomain,
   resolveProvinceForDistrict,
   type ConstituencyBoundaryTopology,
-  type ConstituencyMapRegion,
-  type ConstituencyMetricMode
+  type ConstituencyMapRegion
 } from "../lib/constituency-map.js";
 import {
   loadConstituencyBoundariesIndex,
@@ -33,27 +33,10 @@ const MAP_WIDTH = 920;
 const MAP_HEIGHT = 760;
 const COLOR_LOW = "#f6e8d5";
 const COLOR_HIGH = "#7b3128";
-const METRIC_OPTIONS: Array<{
-  key: ConstituencyMetricMode;
-  label: string;
-  description: string;
-}> = [
-  {
-    key: "absent",
-    label: "불참 비중",
-    description: "진한 색일수록 해당 지역구 대표 의원의 불참 비중이 높습니다."
-  },
-  {
-    key: "negative",
-    label: "반대·기권 비중",
-    description: "진한 색일수록 반대·기권 비중이 높습니다."
-  },
-  {
-    key: "attendance",
-    label: "출석률",
-    description: "진한 색일수록 출석률이 낮습니다."
-  }
-];
+const COLOR_INTENSITY_MIN = 0.14;
+const COLOR_INTENSITY_MAX = 0.96;
+const ATTENDANCE_METRIC_MODE = "attendance";
+const ATTENDANCE_LEGEND_COPY = "현재 지도 안에서 진한 색일수록 출석률이 낮습니다.";
 
 function mixHexColor(startHex: string, endHex: string, ratio: number): string {
   const normalized = Math.min(1, Math.max(0, ratio));
@@ -69,7 +52,10 @@ function mixHexColor(startHex: string, endHex: string, ratio: number): string {
   return `#${channels.join("")}`;
 }
 
-function getRegionFill(region: ConstituencyMapRegion, metricMode: ConstituencyMetricMode): string {
+function getRegionFill(
+  region: ConstituencyMapRegion,
+  metricDomain: ReturnType<typeof getConstituencyMetricDomain>
+): string {
   if (!region.member) {
     return "rgba(214, 203, 191, 0.45)";
   }
@@ -78,19 +64,14 @@ function getRegionFill(region: ConstituencyMapRegion, metricMode: ConstituencyMe
     return "rgba(191, 178, 163, 0.42)";
   }
 
-  const rawValue = getConstituencyMetricValue(region.member, metricMode);
-  const intensity = metricMode === "attendance" ? 1 - rawValue : rawValue;
-  return mixHexColor(COLOR_LOW, COLOR_HIGH, Math.max(0.14, Math.min(0.96, intensity)));
-}
-
-function getActiveMetricMeta(metricMode: ConstituencyMetricMode) {
-  return (
-    METRIC_OPTIONS.find((metric) => metric.key === metricMode) ?? {
-      key: "absent",
-      label: "불참 비중",
-      description: "진한 색일수록 해당 지역구 대표 의원의 불참 비중이 높습니다."
-    }
+  const normalizedIntensity = getConstituencyMetricColorIntensity(
+    region.member,
+    ATTENDANCE_METRIC_MODE,
+    metricDomain
   );
+  const intensity =
+    COLOR_INTENSITY_MIN + normalizedIntensity * (COLOR_INTENSITY_MAX - COLOR_INTENSITY_MIN);
+  return mixHexColor(COLOR_LOW, COLOR_HIGH, intensity);
 }
 
 function buildRegionScopeText(args: {
@@ -103,7 +84,7 @@ function buildRegionScopeText(args: {
   }
 
   if (args.highlightedRegions.length === args.matchedRegions.length) {
-    return `현재 province에서 ${formatNumber(args.matchedRegions.length)}개 지역구 통계를 연결했습니다.`;
+    return `현재 선택한 지역에서 ${formatNumber(args.matchedRegions.length)}개 지역구 통계를 연결했습니다.`;
   }
 
   return `필터 조건 안에서 ${formatNumber(args.highlightedRegions.length)}개 지역구를 강조하고, 나머지 ${formatNumber(args.matchedRegions.length - args.highlightedRegions.length)}개는 옅게 유지합니다.`;
@@ -112,27 +93,34 @@ function buildRegionScopeText(args: {
 function DistributionConstituencyMapDetail({
   region,
   selectedMemberId,
-  onSelectMember
+  onSelectMember,
+  variant = "full"
 }: {
   region: ConstituencyMapRegion | null;
   selectedMemberId: string | null;
   onSelectMember: (memberId: string) => void;
+  variant?: "compact" | "full";
 }) {
+  const detailClassName =
+    variant === "compact"
+      ? "distribution-map__detail distribution-map__detail--compact"
+      : "distribution-map__detail";
+
   if (!region) {
     return (
-      <aside className="distribution-map__detail" aria-live="polite">
-        <p className="section-label">선택 지역구</p>
+      <aside className={detailClassName} aria-live="polite">
+        <p className="section-label">{variant === "compact" ? "현재 선택" : "선택 지역구"}</p>
         <h3>지도에서 지역구를 선택해 주세요.</h3>
         <p className="distribution-page__search-note">
-          지도 클릭 또는 province 전환으로 지역구별 통계를 살펴볼 수 있습니다.
+          지도 클릭 또는 지역 전환으로 지역구별 통계를 살펴볼 수 있습니다.
         </p>
       </aside>
     );
   }
 
   return (
-    <aside className="distribution-map__detail" aria-live="polite">
-      <p className="section-label">선택 지역구</p>
+    <aside className={detailClassName} aria-live="polite">
+      <p className="section-label">{variant === "compact" ? "현재 선택" : "선택 지역구"}</p>
       <h3>{region.properties.memberDistrictLabel}</h3>
       <p className="distribution-map__detail-area">{region.properties.areaText}</p>
       {region.member ? (
@@ -141,7 +129,7 @@ function DistributionConstituencyMapDetail({
             name={region.member.name}
             party={region.member.party}
             photoUrl={region.member.photoUrl}
-            size="large"
+            size={variant === "compact" ? "medium" : "large"}
           />
           <div className="distribution-map__detail-actions">
             <button
@@ -151,8 +139,12 @@ function DistributionConstituencyMapDetail({
               disabled={selectedMemberId === region.member.memberId}
             >
               {selectedMemberId === region.member.memberId
-                ? "현재 분포 상세와 연결됨"
-                : "이 의원 상세와 연결"}
+                ? variant === "compact"
+                  ? "현재 상세와 연결됨"
+                  : "현재 분포 상세와 연결됨"
+                : variant === "compact"
+                  ? "이 의원 상세 보기"
+                  : "이 의원 상세와 연결"}
             </button>
           </div>
           <div className="distribution-map__detail-metrics">
@@ -168,45 +160,55 @@ function DistributionConstituencyMapDetail({
               <span>반대·기권 비중</span>
               <strong>{formatPercent(region.member.negativeRate)}</strong>
             </article>
-            <article>
-              <span>현재 연속 패턴</span>
-              <strong>{`${formatNumber(region.member.currentNegativeOrAbsentStreak)}일`}</strong>
-            </article>
+            {variant === "compact" ? null : (
+              <article>
+                <span>현재 연속 패턴</span>
+                <strong>{`${formatNumber(region.member.currentNegativeOrAbsentStreak)}일`}</strong>
+              </article>
+            )}
           </div>
-          <dl className="distribution-map__detail-facts">
-            <div>
-              <dt>대표 의원</dt>
-              <dd>{`${region.member.name} · ${region.member.party}`}</dd>
-            </div>
-            <div>
-              <dt>기록표결</dt>
-              <dd>{`${formatNumber(region.member.totalRecordedVotes)}건`}</dd>
-            </div>
-            <div>
-              <dt>시군구</dt>
-              <dd>{region.properties.sigunguNames.join(", ")}</dd>
-            </div>
-            <div>
-              <dt>읍면동 수</dt>
-              <dd>{`${formatNumber(region.properties.emdNames.length)}개`}</dd>
-            </div>
-          </dl>
+          {variant === "compact" ? (
+            <p className="distribution-page__search-note">
+              {`${region.member.party} · 기록표결 ${formatNumber(region.member.totalRecordedVotes)}건 · 현재 연속 패턴 ${formatNumber(region.member.currentNegativeOrAbsentStreak)}일`}
+            </p>
+          ) : (
+            <dl className="distribution-map__detail-facts">
+              <div>
+                <dt>대표 의원</dt>
+                <dd>{`${region.member.name} · ${region.member.party}`}</dd>
+              </div>
+              <div>
+                <dt>기록표결</dt>
+                <dd>{`${formatNumber(region.member.totalRecordedVotes)}건`}</dd>
+              </div>
+              <div>
+                <dt>시군구</dt>
+                <dd>{region.properties.sigunguNames.join(", ")}</dd>
+              </div>
+              <div>
+                <dt>읍면동 수</dt>
+                <dd>{`${formatNumber(region.properties.emdNames.length)}개`}</dd>
+              </div>
+            </dl>
+          )}
         </>
       ) : (
         <>
           <p className="distribution-page__search-note">
             이 지역구는 boundary는 준비됐지만 현재 의원 통계 export와의 연결이 아직 없습니다.
           </p>
-          <dl className="distribution-map__detail-facts">
-            <div>
-              <dt>시군구</dt>
-              <dd>{region.properties.sigunguNames.join(", ")}</dd>
-            </div>
-            <div>
-              <dt>읍면동 수</dt>
-              <dd>{`${formatNumber(region.properties.emdNames.length)}개`}</dd>
-            </div>
-          </dl>
+          {variant === "compact" ? null : (
+            <dl className="distribution-map__detail-facts">
+              <div>
+                <dt>시군구</dt>
+                <dd>{region.properties.sigunguNames.join(", ")}</dd>
+              </div>
+              <div>
+                <dt>읍면동 수</dt>
+                <dd>{`${formatNumber(region.properties.emdNames.length)}개`}</dd>
+              </div>
+            </dl>
+          )}
         </>
       )}
     </aside>
@@ -230,7 +232,6 @@ export function DistributionConstituencyMap({
   const [isProvinceLoading, setIsProvinceLoading] = useState(false);
   const [provinceError, setProvinceError] = useState<string | null>(null);
   const [selectedDistrictKey, setSelectedDistrictKey] = useState<string | null>(null);
-  const [metricMode, setMetricMode] = useState<ConstituencyMetricMode>("absent");
 
   const selectedMember = useMemo(
     () => members.find((member) => member.memberId === selectedMemberId) ?? null,
@@ -372,6 +373,10 @@ export function DistributionConstituencyMap({
     () => matchedRegions.filter((region) => region.highlighted),
     [matchedRegions]
   );
+  const metricDomain = useMemo(
+    () => getConstituencyMetricDomain(regions, ATTENDANCE_METRIC_MODE),
+    [regions]
+  );
   const selectedMemberRegion = useMemo(
     () => regions.find((region) => region.member?.memberId === selectedMemberId) ?? null,
     [regions, selectedMemberId]
@@ -392,19 +397,20 @@ export function DistributionConstituencyMap({
     setSelectedDistrictKey(selectedRegion.districtKey);
   }, [selectedDistrictKey, selectedRegion]);
 
+  const visibleRegions = highlightedRegions.length > 0 ? highlightedRegions : matchedRegions;
   const provinceAttendanceAverage =
-    highlightedRegions.length > 0
-      ? highlightedRegions.reduce(
-          (sum, region) => sum + (region.member?.attendanceRate ?? 0),
-          0
-        ) / highlightedRegions.length
+    visibleRegions.length > 0
+      ? visibleRegions.reduce((sum, region) => sum + (region.member?.attendanceRate ?? 0), 0) /
+        visibleRegions.length
       : 0;
-  const provinceAbsenceAverage =
-    highlightedRegions.length > 0
-      ? highlightedRegions.reduce((sum, region) => sum + (region.member?.absentRate ?? 0), 0) /
-        highlightedRegions.length
+  const provinceLowestAttendanceRate =
+    visibleRegions.length > 0
+      ? Math.min(...visibleRegions.map((region) => region.member?.attendanceRate ?? 0))
       : 0;
-  const activeMetricMeta = getActiveMetricMeta(metricMode);
+  const selectedCohortLabel =
+    highlightedRegions.length > 0 ? "현재 강조 집합 기준" : "현재 지역 전체 기준";
+  const matchedCoverageLabel =
+    regions.length > 0 ? "boundary 대비 현재 의원 연결 수" : "표시할 지역구 없음";
 
   function handleSelectProvince(provinceShortName: string) {
     setActiveProvinceShortName(provinceShortName);
@@ -425,7 +431,7 @@ export function DistributionConstituencyMap({
         <p className="section-label">지역구 지도</p>
         <h2>지역구 boundary를 불러오는 중입니다.</h2>
         <p className="distribution-page__search-note">
-          manifest와 province shard를 확인한 뒤 지도 패널을 엽니다.
+          manifest와 지역 shard를 확인한 뒤 지도 패널을 엽니다.
         </p>
       </section>
     );
@@ -447,7 +453,7 @@ export function DistributionConstituencyMap({
         <p className="section-label">지역구 지도</p>
         <h2>배포 데이터에 지역구 boundary export가 아직 없습니다.</h2>
         <p className="distribution-page__search-note">
-          `exports/constituency_boundaries/index.json`이 발행되면 같은 distribution route 안에서 상세 지도를 바로 열 수 있습니다.
+          `exports/constituency_boundaries/index.json`이 발행되면 같은 분포 화면 안에서 상세 지도를 바로 열 수 있습니다.
         </p>
       </section>
     );
@@ -460,64 +466,52 @@ export function DistributionConstituencyMap({
           <p className="section-label">지역구 지도</p>
           <h2>{`${activeProvince?.provinceShortName ?? "선택한"} 지역구별 핵심 통계`}</h2>
           <p className="distribution-page__search-note">
-            지도에서 선거구를 누르면 대표 의원과 출석, 불참, 반대·기권 패턴을 같은 화면에서 확인할 수 있습니다.
+            지도에서 선거구를 누르면 대표 의원과 출석 흐름을 먼저 보고, 상세 패널에서 다른 표결 지표를 함께 확인할 수 있습니다.
           </p>
         </div>
         <div className="distribution-map__summary-grid" aria-label="지역구 지도 요약">
           <article className="chart-card__summary">
             <span>매칭 지역구</span>
             <strong>{`${formatNumber(matchedRegions.length)} / ${formatNumber(regions.length)}`}</strong>
-            <small>boundary 대비 current member 연결 수</small>
+            <small>{matchedCoverageLabel}</small>
           </article>
           <article className="chart-card__summary">
             <span>평균 출석률</span>
             <strong>{formatPercent(provinceAttendanceAverage)}</strong>
-            <small>현재 강조 cohort 기준</small>
+            <small>{selectedCohortLabel}</small>
           </article>
           <article className="chart-card__summary">
-            <span>평균 불참 비중</span>
-            <strong>{formatPercent(provinceAbsenceAverage)}</strong>
-            <small>현재 강조 cohort 기준</small>
+            <span>가장 낮은 출석률</span>
+            <strong>{formatPercent(provinceLowestAttendanceRate)}</strong>
+            <small>{selectedCohortLabel}</small>
           </article>
         </div>
       </div>
 
       <div className="distribution-map__controls">
-        <div className="distribution-map__province-list" role="tablist" aria-label="province 선택">
-          {boundaryIndex.provinces.map((province) => (
-            <button
-              key={province.provinceShortName}
-              type="button"
-              className={
-                province.provinceShortName === activeProvinceShortName
-                  ? "distribution-map__province-button is-active"
-                  : "distribution-map__province-button"
-              }
-              aria-selected={province.provinceShortName === activeProvinceShortName}
-              onClick={() => handleSelectProvince(province.provinceShortName)}
-            >
-              <span>{province.provinceShortName}</span>
-              <strong>{`${formatNumber(province.featureCount)}곳`}</strong>
-            </button>
-          ))}
-        </div>
-        <div className="distribution-map__metric-list" aria-label="지도 색상 기준">
-          {METRIC_OPTIONS.map((metric) => (
-            <button
-              key={metric.key}
-              type="button"
-              className={
-                metric.key === metricMode
-                  ? "distribution-map__metric-button is-active"
-                  : "distribution-map__metric-button"
-              }
-              aria-pressed={metric.key === metricMode}
-              onClick={() => setMetricMode(metric.key)}
-            >
-              {metric.label}
-            </button>
-          ))}
-        </div>
+        <label className="distribution-map__province-picker">
+          <span className="distribution-map__field-label">지역 선택</span>
+          <select
+            className="distribution-map__province-select"
+            aria-label="지역 선택"
+            value={activeProvinceShortName ?? ""}
+            onChange={(event) => handleSelectProvince(event.currentTarget.value)}
+          >
+            {activeProvinceShortName ? null : (
+              <option value="" disabled>
+                지역을 선택해 주세요
+              </option>
+            )}
+            {boundaryIndex.provinces.map((province) => (
+              <option key={province.provinceShortName} value={province.provinceShortName}>
+                {`${province.provinceShortName} · ${formatNumber(province.featureCount)}곳`}
+              </option>
+            ))}
+          </select>
+        </label>
+        <p className="distribution-map__control-note">
+          지역을 바꾸면 같은 화면에서 해당 지역구 출석률 분포를 다시 읽습니다.
+        </p>
       </div>
 
       <div className="distribution-map__legend">
@@ -525,7 +519,7 @@ export function DistributionConstituencyMap({
           <span />
           <span />
         </div>
-        <p className="distribution-page__search-note">{activeMetricMeta.description}</p>
+        <p className="distribution-page__search-note">{ATTENDANCE_LEGEND_COPY}</p>
         <p className="distribution-page__search-note">
           {buildRegionScopeText({
             matchedRegions,
@@ -536,64 +530,77 @@ export function DistributionConstituencyMap({
       </div>
 
       <div className="distribution-map__layout">
-        <div className="distribution-map__surface">
-          {isProvinceLoading && activeTopology === undefined ? (
-            <div className="distribution-map__state">
-              <h3>{`${activeProvince?.provinceShortName ?? "선택한 province"} 지도를 불러오는 중입니다.`}</h3>
-              <p className="distribution-page__search-note">
-                province shard를 받은 뒤 지역구별 SVG 경계를 그립니다.
-              </p>
+        <div className="distribution-map__surface-frame">
+          <div className="distribution-map__surface">
+            {isProvinceLoading && activeTopology === undefined ? (
+              <div className="distribution-map__state">
+                <h3>{`${activeProvince?.provinceShortName ?? "선택한 지역"} 지도를 불러오는 중입니다.`}</h3>
+                <p className="distribution-page__search-note">
+                  지역 shard를 받은 뒤 지역구별 SVG 경계를 그립니다.
+                </p>
+              </div>
+            ) : provinceError ? (
+              <div className="distribution-map__state">
+                <h3>지역 shard를 열 수 없습니다.</h3>
+                <p className="distribution-page__search-note">{provinceError}</p>
+              </div>
+            ) : activeTopology === null ? (
+              <div className="distribution-map__state">
+                <h3>선택한 지역 shard가 아직 발행되지 않았습니다.</h3>
+                <p className="distribution-page__search-note">
+                  boundary index는 보이지만 실제 지도 파일이 없어 로컬 기준으로만 준비된 상태입니다.
+                </p>
+              </div>
+            ) : (
+              <svg
+                className="distribution-map__svg"
+                viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
+                role="img"
+                aria-label={`${activeProvince?.provinceShortName ?? "선택한 지역"} 지역구 지도`}
+              >
+                {regions.map((region) => {
+                  const isSelected = selectedRegion?.districtKey === region.districtKey;
+                  return (
+                    <g
+                      key={region.districtKey}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={region.properties.memberDistrictLabel}
+                      onClick={() => handleSelectRegion(region)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          handleSelectRegion(region);
+                        }
+                      }}
+                    >
+                      <title>{region.properties.memberDistrictLabel}</title>
+                      <path
+                        d={region.path}
+                        className={
+                          isSelected
+                            ? "distribution-map__region is-selected"
+                            : "distribution-map__region"
+                        }
+                        fill={getRegionFill(region, metricDomain)}
+                      />
+                    </g>
+                  );
+                })}
+              </svg>
+            )}
+          </div>
+
+          {activeTopology ? (
+            <div className="distribution-map__mobile-detail-shell">
+              <DistributionConstituencyMapDetail
+                region={selectedRegion}
+                selectedMemberId={selectedMemberId}
+                onSelectMember={onSelectMember}
+                variant="compact"
+              />
             </div>
-          ) : provinceError ? (
-            <div className="distribution-map__state">
-              <h3>province shard를 열 수 없습니다.</h3>
-              <p className="distribution-page__search-note">{provinceError}</p>
-            </div>
-          ) : activeTopology === null ? (
-            <div className="distribution-map__state">
-              <h3>선택한 province shard가 아직 발행되지 않았습니다.</h3>
-              <p className="distribution-page__search-note">
-                boundary index는 보이지만 실제 지도 파일이 없어 로컬 기준으로만 준비된 상태입니다.
-              </p>
-            </div>
-          ) : (
-            <svg
-              className="distribution-map__svg"
-              viewBox={`0 0 ${MAP_WIDTH} ${MAP_HEIGHT}`}
-              role="img"
-              aria-label={`${activeProvince?.provinceShortName ?? "선택한 province"} 지역구 지도`}
-            >
-              {regions.map((region) => {
-                const isSelected = selectedRegion?.districtKey === region.districtKey;
-                return (
-                  <g
-                    key={region.districtKey}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={region.properties.memberDistrictLabel}
-                    onClick={() => handleSelectRegion(region)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        handleSelectRegion(region);
-                      }
-                    }}
-                  >
-                    <title>{region.properties.memberDistrictLabel}</title>
-                    <path
-                      d={region.path}
-                      className={
-                        isSelected
-                          ? "distribution-map__region is-selected"
-                          : "distribution-map__region"
-                      }
-                      fill={getRegionFill(region, metricMode)}
-                    />
-                  </g>
-                );
-              })}
-            </svg>
-          )}
+          ) : null}
         </div>
 
         <DistributionConstituencyMapDetail

--- a/apps/web/src/lib/constituency-map.ts
+++ b/apps/web/src/lib/constituency-map.ts
@@ -10,6 +10,11 @@ import type { DistributionMemberPoint } from "./distribution.js";
 
 export type ConstituencyMetricMode = "attendance" | "absent" | "negative";
 
+export type ConstituencyMetricDomain = {
+  min: number;
+  max: number;
+};
+
 export type ConstituencyBoundaryTopology = {
   type: "Topology";
   objects: {
@@ -101,6 +106,64 @@ export function getConstituencyMetricValue(
   }
 
   return member.negativeRate;
+}
+
+export function getConstituencyMetricRenderValue(
+  member: DistributionMemberPoint,
+  metricMode: ConstituencyMetricMode
+): number {
+  const value = getConstituencyMetricValue(member, metricMode);
+  return metricMode === "attendance" ? 1 - value : value;
+}
+
+function collectConstituencyMetricValues(
+  regions: Array<Pick<ConstituencyMapRegion, "member" | "highlighted">>,
+  metricMode: ConstituencyMetricMode
+): number[] {
+  return regions.flatMap((region) =>
+    region.member ? [getConstituencyMetricRenderValue(region.member, metricMode)] : []
+  );
+}
+
+export function getConstituencyMetricDomain(
+  regions: Array<Pick<ConstituencyMapRegion, "member" | "highlighted">>,
+  metricMode: ConstituencyMetricMode
+): ConstituencyMetricDomain {
+  const highlightedValues = collectConstituencyMetricValues(
+    regions.filter((region) => region.highlighted),
+    metricMode
+  );
+  const fallbackValues =
+    highlightedValues.length >= 2
+      ? highlightedValues
+      : collectConstituencyMetricValues(regions, metricMode);
+
+  if (fallbackValues.length < 2) {
+    return {
+      min: 0,
+      max: 1
+    };
+  }
+
+  return {
+    min: Math.min(...fallbackValues),
+    max: Math.max(...fallbackValues)
+  };
+}
+
+export function getConstituencyMetricColorIntensity(
+  member: DistributionMemberPoint,
+  metricMode: ConstituencyMetricMode,
+  domain: ConstituencyMetricDomain
+): number {
+  const value = getConstituencyMetricRenderValue(member, metricMode);
+  const span = domain.max - domain.min;
+
+  if (!Number.isFinite(span) || span <= 0) {
+    return Math.min(1, Math.max(0, value));
+  }
+
+  return Math.min(1, Math.max(0, (value - domain.min) / span));
 }
 
 function buildFeatureLookupKeys(properties: ConstituencyBoundaryProperties): string[] {

--- a/apps/web/src/styles/distribution-refresh.css
+++ b/apps/web/src/styles/distribution-refresh.css
@@ -22,6 +22,7 @@
 .distribution-map,
 .distribution-map__header,
 .distribution-map__controls,
+.distribution-map__province-picker,
 .distribution-map__province-list,
 .distribution-map__metric-list,
 .distribution-map__legend,
@@ -146,6 +147,42 @@
   gap: 0.72rem;
 }
 
+.distribution-map__province-picker {
+  max-width: 18rem;
+}
+
+.distribution-map__field-label {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.distribution-map__province-select {
+  width: 100%;
+  min-height: 2.95rem;
+  padding: 0.75rem 0.95rem;
+  border: 1px solid rgba(72, 56, 40, 0.12);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--accent-strong);
+  font: inherit;
+  box-shadow: 0 14px 28px rgba(72, 56, 40, 0.1);
+}
+
+.distribution-map__province-select:focus-visible {
+  outline: 2px solid rgba(123, 49, 40, 0.28);
+  outline-offset: 2px;
+}
+
+.distribution-map__control-note {
+  margin: 0;
+  max-width: 32rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
 .distribution-map__province-list,
 .distribution-map__metric-list {
   grid-template-columns: repeat(auto-fit, minmax(5.5rem, max-content));
@@ -212,6 +249,15 @@
   align-items: start;
 }
 
+.distribution-map__surface-frame {
+  position: relative;
+  min-width: 0;
+}
+
+.distribution-map__mobile-detail-shell {
+  display: none;
+}
+
 .distribution-map__surface,
 .distribution-map__detail,
 .distribution-map__state {
@@ -262,6 +308,15 @@
   padding: 1rem;
 }
 
+.distribution-map__detail--compact {
+  gap: 0.65rem;
+  padding: 0.9rem;
+  border-color: rgba(123, 49, 40, 0.16);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(247, 240, 231, 0.98));
+  box-shadow: 0 18px 34px rgba(72, 56, 40, 0.16);
+}
+
 .distribution-map__detail-area {
   margin: 0;
   color: var(--text-muted);
@@ -304,6 +359,33 @@
   font-size: 1.15rem;
   line-height: 1;
   letter-spacing: -0.03em;
+}
+
+.distribution-map__detail--compact .distribution-map__detail-area {
+  font-size: 0.84rem;
+}
+
+.distribution-map__detail--compact .distribution-map__detail-actions {
+  margin-top: 0;
+}
+
+.distribution-map__detail--compact .distribution-map__detail-metrics {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.distribution-map__detail--compact .distribution-map__detail-metrics article {
+  padding: 0.7rem 0.68rem;
+  border-radius: 16px;
+}
+
+.distribution-map__detail--compact .distribution-map__detail-metrics span {
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+}
+
+.distribution-map__detail--compact .distribution-map__detail-metrics strong {
+  font-size: 0.98rem;
 }
 
 .distribution-map__detail-facts {
@@ -787,6 +869,26 @@
   .distribution-map__state {
     padding: 0.8rem;
     border-radius: 18px;
+  }
+
+  .distribution-map__surface {
+    padding-bottom: 11rem;
+  }
+
+  .distribution-map__mobile-detail-shell {
+    display: block;
+    position: absolute;
+    inset: auto 0.8rem 0.8rem;
+    z-index: 2;
+    pointer-events: none;
+  }
+
+  .distribution-map__mobile-detail-shell .distribution-map__detail {
+    pointer-events: auto;
+  }
+
+  .distribution-map__layout > .distribution-map__detail {
+    display: none;
   }
 
   .distribution-chart__help-button {

--- a/tests/web/app.test.tsx
+++ b/tests/web/app.test.tsx
@@ -276,12 +276,21 @@ describe("web app", () => {
         name: "위로 갈수록 반대·기권 비중이 낮고, 오른쪽으로 갈수록 출석률이 높습니다."
       })
     ).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "부산 남구" })).toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { name: "부산 남구" }).length).toBeGreaterThan(0);
     expect(screen.getByRole("combobox", { name: "분포에서 의원 찾기" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "지역 선택" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "불참 비중" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "반대·기권 비중" })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "활동 캘린더 열기" })).toHaveAttribute(
       "href",
       "#calendar?member=M002"
     );
+    const compactMapDetail = document.querySelector(".distribution-map__detail--compact");
+    expect(compactMapDetail).not.toBeNull();
+    expect(within(compactMapDetail as HTMLElement).getByText("박민")).toBeInTheDocument();
+    expect(
+      within(compactMapDetail as HTMLElement).getByRole("button", { name: "현재 상세와 연결됨" })
+    ).toBeDisabled();
     expect(screen.getByText("반대·기권 비중이 높은 의원")).toBeInTheDocument();
     expect(
       screen.getByText("정당 평균을 눌러 차트를 해당 정당만 남기는 강조 모드로 전환합니다.")
@@ -293,8 +302,9 @@ describe("web app", () => {
     render(<App />);
 
     expect(await screen.findByRole("heading", { name: "부산 지역구별 핵심 통계" })).toBeInTheDocument();
-    const provinceTabs = screen.getByRole("tablist", { name: "province 선택" });
-    fireEvent.click(within(provinceTabs).getByRole("button", { name: /서울/ }));
+    fireEvent.change(screen.getByRole("combobox", { name: "지역 선택" }), {
+      target: { value: "서울" }
+    });
 
     expect(await screen.findByRole("heading", { name: "서울 지역구별 핵심 통계" })).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText("서울 중구"));
@@ -302,8 +312,12 @@ describe("web app", () => {
     await waitFor(() => {
       expect(window.location.hash).toBe("#distribution?member=M001");
     });
+    const compactMapDetail = document.querySelector(".distribution-map__detail--compact");
+    expect(compactMapDetail).not.toBeNull();
+    expect(within(compactMapDetail as HTMLElement).getByText("김아라")).toBeInTheDocument();
+    expect(within(compactMapDetail as HTMLElement).getByText("명동, 회현동")).toBeInTheDocument();
     expect(screen.getAllByText("김아라").length).toBeGreaterThan(0);
-    expect(screen.getByText("명동, 회현동")).toBeInTheDocument();
+    expect(screen.getAllByText("명동, 회현동").length).toBeGreaterThan(0);
   });
 
   it("reveals the distribution help copy only when requested", async () => {


### PR DESCRIPTION
## Summary
- simplify the constituency map color scale to an attendance-only view
- replace the province button strip with a labeled select control and add the mobile compact detail shell
- carry the missing constituency-map metric domain helpers so the shared branch matches the verified local handoff

## Why
- the product request for NIT-356 keeps only the attendance framing on the constituency map and removes the other metric toggles
- the local handoff artifact validated the UI change, but the shared `main`-based publish slice still needed the helper exports that power the normalized attendance color scale

## Impact
- analysts now get a single attendance-oriented map legend and province picker flow
- mobile users keep a compact selected-district detail panel without losing the linked member action

## Validation
- `npm run test -- tests/web/app.test.tsx tests/web/constituency-map.test.tsx`
- `npm run build`

## Root cause
- the original local-only handoff patch did not include the `constituency-map` helper additions required by the updated component when replayed on top of `main`
