### PR TITLE
[codex] Publish NIT-360 mobile map layout fix

### DIFF
--- a/apps/web/src/components/DistributionConstituencyMap.tsx
+++ b/apps/web/src/components/DistributionConstituencyMap.tsx
@@ -222,6 +222,7 @@ export function DistributionConstituencyMap({
   selectedMemberId,
   onSelectMember
 }: DistributionConstituencyMapProps) {
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [boundaryIndex, setBoundaryIndex] = useState<ConstituencyBoundariesIndexExport | null>(null);
   const [isIndexLoading, setIsIndexLoading] = useState(false);
   const [indexError, setIndexError] = useState<string | null>(null);
@@ -411,6 +412,11 @@ export function DistributionConstituencyMap({
     highlightedRegions.length > 0 ? "현재 강조 집합 기준" : "현재 지역 전체 기준";
   const matchedCoverageLabel =
     regions.length > 0 ? "boundary 대비 현재 의원 연결 수" : "표시할 지역구 없음";
+  const regionScopeText = buildRegionScopeText({
+    matchedRegions,
+    highlightedRegions,
+    totalRegions: regions.length
+  });
 
   function handleSelectProvince(provinceShortName: string) {
     setActiveProvinceShortName(provinceShortName);
@@ -463,11 +469,20 @@ export function DistributionConstituencyMap({
     <section className="distribution-map" aria-label="지역구 지도 패널">
       <div className="distribution-map__header">
         <div>
-          <p className="section-label">지역구 지도</p>
+          <div className="distribution-map__eyebrow">
+            <p className="section-label">지역구 지도</p>
+            <button
+              type="button"
+              className="distribution-map__help-button"
+              aria-label={isHelpOpen ? "지역구 지도 설명 닫기" : "지역구 지도 설명 보기"}
+              aria-expanded={isHelpOpen}
+              aria-controls="distribution-map-help"
+              onClick={() => setIsHelpOpen((current) => !current)}
+            >
+              ?
+            </button>
+          </div>
           <h2>{`${activeProvince?.provinceShortName ?? "선택한"} 지역구별 핵심 통계`}</h2>
-          <p className="distribution-page__search-note">
-            지도에서 선거구를 누르면 대표 의원과 출석 흐름을 먼저 보고, 상세 패널에서 다른 표결 지표를 함께 확인할 수 있습니다.
-          </p>
         </div>
         <div className="distribution-map__summary-grid" aria-label="지역구 지도 요약">
           <article className="chart-card__summary">
@@ -509,25 +524,31 @@ export function DistributionConstituencyMap({
             ))}
           </select>
         </label>
-        <p className="distribution-map__control-note">
-          지역을 바꾸면 같은 화면에서 해당 지역구 출석률 분포를 다시 읽습니다.
-        </p>
       </div>
 
       <div className="distribution-map__legend">
+        <span className="distribution-map__legend-label">높은 출석</span>
         <div className="distribution-map__legend-scale" aria-hidden="true">
           <span />
           <span />
         </div>
-        <p className="distribution-page__search-note">{ATTENDANCE_LEGEND_COPY}</p>
-        <p className="distribution-page__search-note">
-          {buildRegionScopeText({
-            matchedRegions,
-            highlightedRegions,
-            totalRegions: regions.length
-          })}
-        </p>
+        <span className="distribution-map__legend-label distribution-map__legend-label--end">
+          낮은 출석
+        </span>
       </div>
+
+      {isHelpOpen ? (
+        <div id="distribution-map-help" className="distribution-map__help-panel" role="note">
+          <p className="distribution-page__search-note">
+            지도에서 선거구를 누르면 대표 의원과 출석 흐름을 먼저 보고, 상세 패널에서 다른 표결 지표를 함께 확인할 수 있습니다.
+          </p>
+          <p className="distribution-page__search-note">
+            지역을 바꾸면 같은 화면에서 해당 지역구 출석률 분포를 다시 읽습니다.
+          </p>
+          <p className="distribution-page__search-note">{ATTENDANCE_LEGEND_COPY}</p>
+          <p className="distribution-page__search-note">{regionScopeText}</p>
+        </div>
+      ) : null}
 
       <div className="distribution-map__layout">
         <div className="distribution-map__surface-frame">

--- a/apps/web/src/styles/distribution-refresh.css
+++ b/apps/web/src/styles/distribution-refresh.css
@@ -20,6 +20,7 @@
 .distribution-page__headline,
 .distribution-page__search,
 .distribution-map,
+.distribution-map__eyebrow,
 .distribution-map__header,
 .distribution-map__controls,
 .distribution-map__province-picker,
@@ -143,6 +144,12 @@
   gap: 0.72rem;
 }
 
+.distribution-map__eyebrow {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .distribution-map__controls {
   gap: 0.72rem;
 }
@@ -227,9 +234,9 @@
 }
 
 .distribution-map__legend {
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(8.5rem, 1fr) auto;
   align-items: center;
-  gap: 0.5rem 0.85rem;
+  gap: 0.5rem 0.75rem;
 }
 
 .distribution-map__legend-scale {
@@ -242,6 +249,17 @@
 
 .distribution-map__legend-scale span {
   display: none;
+}
+
+.distribution-map__legend-label {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.distribution-map__legend-label--end {
+  text-align: right;
 }
 
 .distribution-map__layout {
@@ -444,6 +462,7 @@
   gap: 0.72rem;
 }
 
+.distribution-map__help-button,
 .distribution-chart__help-button {
   display: inline-flex;
   align-items: center;
@@ -462,20 +481,35 @@
   box-shadow: 0 12px 26px rgba(72, 56, 40, 0.12);
 }
 
+.distribution-map__help-button:focus-visible,
+.distribution-chart__help-button:focus-visible {
+  outline: 2px solid rgba(123, 49, 40, 0.28);
+  outline-offset: 2px;
+}
+
+.distribution-map__help-button:hover,
 .distribution-chart__help-button:hover {
   border-color: rgba(123, 49, 40, 0.24);
   background: rgba(255, 255, 255, 0.98);
   box-shadow: 0 16px 30px rgba(123, 49, 40, 0.16);
 }
 
+.distribution-map__help-panel,
 .distribution-chart__help-panel {
   display: grid;
   gap: 0.5rem;
-  margin-top: 0.85rem;
   padding: 0.85rem 0.95rem;
   border: 1px solid rgba(72, 56, 40, 0.1);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.66);
+}
+
+.distribution-map__help-panel {
+  margin-top: 0.25rem;
+}
+
+.distribution-chart__help-panel {
+  margin-top: 0.85rem;
 }
 
 .distribution-chart__surface {
@@ -864,6 +898,33 @@
     border-radius: 18px;
   }
 
+  .distribution-map__header,
+  .distribution-map__controls {
+    gap: 0.65rem;
+  }
+
+  .distribution-map__summary-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.55rem;
+  }
+
+  .distribution-map__summary-grid .chart-card__summary {
+    padding: 0.78rem 0.72rem;
+  }
+
+  .distribution-map__summary-grid .chart-card__summary strong {
+    font-size: 1.02rem;
+  }
+
+  .distribution-map__legend {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .distribution-map__help-panel {
+    padding: 0.8rem 0.85rem;
+    border-radius: 16px;
+  }
+
   .distribution-map__surface,
   .distribution-map__detail,
   .distribution-map__state {
@@ -871,26 +932,17 @@
     border-radius: 18px;
   }
 
-  .distribution-map__surface {
-    padding-bottom: 11rem;
-  }
-
   .distribution-map__mobile-detail-shell {
     display: block;
-    position: absolute;
-    inset: auto 0.8rem 0.8rem;
-    z-index: 2;
-    pointer-events: none;
-  }
-
-  .distribution-map__mobile-detail-shell .distribution-map__detail {
-    pointer-events: auto;
+    position: static;
+    margin-top: 0.8rem;
   }
 
   .distribution-map__layout > .distribution-map__detail {
     display: none;
   }
 
+  .distribution-map__help-button,
   .distribution-chart__help-button {
     width: 2.75rem;
     height: 2.75rem;

--- a/tests/fixtures/contracts/manifest.json
+++ b/tests/fixtures/contracts/manifest.json
@@ -64,6 +64,12 @@
       "url": "https://data.example.test/lawmaker-monitor/exports/member_activity_calendar.json",
       "checksumSha256": "member-activity-calendar-checksum",
       "rowCount": 3
+    },
+    "constituencyBoundariesIndex": {
+      "path": "exports/constituency_boundaries/index.json",
+      "url": "https://data.example.test/lawmaker-monitor/exports/constituency_boundaries/index.json",
+      "checksumSha256": "constituency-index-checksum",
+      "rowCount": 2
     }
   }
 }

--- a/tests/ui/app-ui.test.ts
+++ b/tests/ui/app-ui.test.ts
@@ -577,10 +577,12 @@ async function openDistributionFlow(viewportName: string): Promise<void> {
 
     await page.getByRole("heading", { name: "제22대 국회 의원 분포" }).waitFor();
     await page.getByRole("combobox", { name: "분포에서 의원 찾기" }).waitFor();
+    await page.getByRole("heading", { name: "부산 지역구별 핵심 통계" }).waitFor();
     await expect
       .poll(async () => page.locator(".distribution-focus__district").textContent())
       .toBe("부산 남구");
     await page.getByText("정당 평균을 눌러 차트를 해당 정당만 남기는 강조 모드로 전환합니다.").waitFor();
+    await page.locator(".distribution-map").scrollIntoViewIfNeeded();
 
     const layout = await page.locator(".distribution-page__layout").evaluate((element) => {
       const layoutElement = element as HTMLElement;
@@ -606,21 +608,70 @@ async function openDistributionFlow(viewportName: string): Promise<void> {
     expect(layout?.chartOverflow ?? 99).toBeLessThanOrEqual(1);
     expect(layout?.focusOverflow ?? 99).toBeLessThanOrEqual(1);
 
+    const mapLayout = await page.locator(".distribution-map").evaluate((element) => {
+      const panel = element as HTMLElement;
+      const panelRect = panel.getBoundingClientRect();
+      const surface = panel.querySelector(".distribution-map__surface") as HTMLElement | null;
+      const fullDetail = panel.querySelector(
+        ".distribution-map__layout > .distribution-map__detail"
+      ) as HTMLElement | null;
+      const mobileDetailShell = panel.querySelector(
+        ".distribution-map__mobile-detail-shell"
+      ) as HTMLElement | null;
+      const compactDetail = mobileDetailShell?.querySelector(
+        ".distribution-map__detail--compact"
+      ) as HTMLElement | null;
+      const helpPanel = panel.querySelector(".distribution-map__help-panel") as HTMLElement | null;
+
+      if (!surface || !fullDetail) {
+        return null;
+      }
+
+      const surfaceRect = surface.getBoundingClientRect();
+      const compactRect = compactDetail?.getBoundingClientRect() ?? null;
+
+      return {
+        surfaceOverflow: surface.scrollWidth - surface.clientWidth,
+        surfaceTopWithinViewport: surfaceRect.top < window.innerHeight,
+        fullDetailDisplay: window.getComputedStyle(fullDetail).display,
+        mobileDetailDisplay: mobileDetailShell
+          ? window.getComputedStyle(mobileDetailShell).display
+          : "none",
+        helpPanelVisible: helpPanel !== null,
+        compactBelowSurface:
+          compactRect !== null &&
+          compactRect.top >= surfaceRect.bottom - 1 &&
+          compactRect.top >= panelRect.top
+      };
+    });
+
+    expect(mapLayout).not.toBeNull();
+    expect(mapLayout?.surfaceOverflow ?? 99).toBeLessThanOrEqual(1);
+
     if (viewportName === "mobile" || viewportName === "tablet") {
       expect(layout?.layoutColumns).toBe(1);
     }
 
     if (viewportName === "mobile") {
       expect(layout?.metricColumns).toBe(1);
+      expect(mapLayout?.mobileDetailDisplay).not.toBe("none");
+      expect(mapLayout?.fullDetailDisplay).toBe("none");
+      expect(mapLayout?.surfaceTopWithinViewport).toBe(true);
+      expect(mapLayout?.helpPanelVisible).toBe(false);
+      expect(mapLayout?.compactBelowSurface).toBe(true);
     }
 
     if (viewportName === "tablet") {
       expect(layout?.metricColumns).toBe(2);
+      expect(mapLayout?.mobileDetailDisplay).toBe("none");
+      expect(mapLayout?.fullDetailDisplay).not.toBe("none");
     }
 
     if (viewportName === "desktop") {
       expect(layout?.layoutColumns).toBe(2);
       expect(layout?.metricColumns).toBe(2);
+      expect(mapLayout?.mobileDetailDisplay).toBe("none");
+      expect(mapLayout?.fullDetailDisplay).not.toBe("none");
     }
 
     const streakSignal = page.getByRole("button", { name: /김아라 미래개혁당/ }).first();
@@ -635,6 +686,15 @@ async function openDistributionFlow(viewportName: string): Promise<void> {
       viewport: viewportName,
       scenario: "distribution-overview",
       screenshot: distributionScreenshot
+    });
+    const distributionMapScreenshot = await saveLocatorScreenshot(
+      page.locator(".distribution-map"),
+      `${viewportName}/distribution-map.png`
+    );
+    scenarioManifest.push({
+      viewport: viewportName,
+      scenario: "distribution-map",
+      screenshot: distributionMapScreenshot
     });
 
     expect(await page.getByRole("link", { name: "활동 캘린더 열기" }).getAttribute("href")).toBe(

--- a/tests/ui/support/ui-harness.ts
+++ b/tests/ui/support/ui-harness.ts
@@ -44,7 +44,19 @@ type BrowserSession = {
 };
 
 const fixtureOverrides = new Map<string, string>([
-  ["/manifests/latest.json", resolve(fixturesRoot, "manifest.json")]
+  ["/manifests/latest.json", resolve(fixturesRoot, "manifest.json")],
+  [
+    "/exports/constituency_boundaries/index.json",
+    resolve(fixturesRoot, "constituency_boundaries_index.json")
+  ],
+  [
+    "/exports/constituency_boundaries/provinces/부산.topo.json",
+    resolve(fixturesRoot, "constituency_province_busan.topo.json")
+  ],
+  [
+    "/exports/constituency_boundaries/provinces/서울.topo.json",
+    resolve(fixturesRoot, "constituency_province_seoul.topo.json")
+  ]
 ]);
 
 function getContentType(filePath: string): string {

--- a/tests/web/app.test.tsx
+++ b/tests/web/app.test.tsx
@@ -320,6 +320,36 @@ describe("web app", () => {
     expect(screen.getAllByText("명동, 회현동").length).toBeGreaterThan(0);
   });
 
+  it("reveals the constituency map help only when requested", async () => {
+    window.location.hash = "#distribution?member=M002";
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "부산 지역구별 핵심 통계" })).toBeInTheDocument();
+    const helpButton = screen.getByRole("button", { name: "지역구 지도 설명 보기" });
+
+    expect(helpButton).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByText(
+        "지도에서 선거구를 누르면 대표 의원과 출석 흐름을 먼저 보고, 상세 패널에서 다른 표결 지표를 함께 확인할 수 있습니다."
+      )
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(helpButton);
+
+    expect(screen.getByRole("button", { name: "지역구 지도 설명 닫기" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    expect(
+      screen.getByText(
+        "지도에서 선거구를 누르면 대표 의원과 출석 흐름을 먼저 보고, 상세 패널에서 다른 표결 지표를 함께 확인할 수 있습니다."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("현재 선택한 지역에서 1개 지역구 통계를 연결했습니다.")
+    ).toBeInTheDocument();
+  });
+
   it("reveals the distribution help copy only when requested", async () => {
     window.location.hash = "#distribution";
     render(<App />);


### PR DESCRIPTION
## What changed

- move the mobile constituency-map compact detail card below the SVG surface so the map is no longer obscured on first view
- hide the longer constituency-map guidance behind an accessible `?` help toggle and tighten the mobile summary/legend spacing
- restore the UI harness boundary fixtures on `main` so the distribution-map regression path passes in the publish branch too

## Why

The reopened `NIT-360` request asked to deploy the mobile map layout refinement. The local-only slice was verified earlier, but `origin/main` still needed both the product-surface change and the UI harness fixture wiring required for shared regression coverage.

## Impact

- mobile analysts reach the map surface sooner and no longer lose SVG area to the compact detail overlay
- the help copy remains available on demand without inflating the default viewport height
- shared `npm run test:ui` coverage now exercises the same constituency-map path that was previously only passing in the dirty local workspace

## Validation

- `npm run test -- tests/web/constituency-map.test.tsx tests/web/app.test.tsx`
- `npm run build --workspace @lawmaker-monitor/web`
- `npm run test:ui`
