### PR TITLE
fix: download constituency boundary from data repo release

### DIFF
--- a/.github/workflows/build-data.yml
+++ b/.github/workflows/build-data.yml
@@ -44,16 +44,15 @@ jobs:
         with:
           build-target: schemas-and-ingest
 
-      - name: Restore constituency boundary cache
-        id: constituency-cache
-        uses: actions/cache@v4
-        with:
-          path: artifacts/constituency-boundaries/current
-          key: constituency-boundaries-${{ hashFiles('packages/ingest/src/constituency-boundaries.ts') }}
-
-      - name: Build constituency boundary source artifact
-        if: steps.constituency-cache.outputs.cache-hit != 'true'
-        run: npm run build:constituency-boundaries --workspace @lawmaker-monitor/ingest
+      - name: Download constituency boundary artifact
+        run: |
+          mkdir -p artifacts/constituency-boundaries/current
+          gh release download constituency-boundaries-v1 \
+            --repo kuil09/lawmaker-monitor-data \
+            --dir artifacts/constituency-boundaries/current \
+            --pattern "*.geojson" --pattern "*.json"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Resolve raw artifact source for manual build
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.raw_source != 'fixtures'


### PR DESCRIPTION
## 원인

GitHub Actions 러너(Azure westus2)가 `data.go.kr`(한국 공공데이터포털)에 접근 불가. 해외 클라우드 IP 대역 차단으로 인해 2026-03-29 constituency boundary 스텝이 도입된 이후 `build-data`가 **매 실행마다 실패** (9회+ 연속).

User-Agent 추가(#16)로는 해결되지 않음 — HTTP 레벨이 아닌 TCP/네트워크 레벨 차단이었기 때문.

## 해법

로컬에서 `build:constituency-boundaries` 실행 → 생성된 `constituency_boundaries.geojson` (228MB)을 `kuil09/lawmaker-monitor-data` 릴리즈 [`constituency-boundaries-v1`](https://github.com/kuil09/lawmaker-monitor-data/releases/tag/constituency-boundaries-v1) 으로 업로드.

CI에서는 `data.go.kr` fetch 없이 GitHub Release에서 직접 다운로드.

## 업데이트 방법

선거구 개편 시:
1. 로컬에서 `npm run build:constituency-boundaries --workspace @lawmaker-monitor/ingest` 실행
2. `gh release upload constituency-boundaries-v1 --repo kuil09/lawmaker-monitor-data --clobber` 로 geojson 교체

## Test plan

- [ ] `build-data` workflow_dispatch 수동 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)