### PR TITLE
style: 패널 상단선 인디고 스타일 및 검색 패널 상단 배치

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -559,26 +559,6 @@ export default function App() {
           </section>
         ) : null}
 
-        {accountabilitySummary ? (
-          <AccountabilityLeaderboard
-            items={accountabilitySummary.items}
-            assemblyLabel={currentAssemblyLabel}
-            attendanceByMemberId={leaderboardAttendanceByMemberId}
-          />
-        ) : (
-          <section className="leaderboard-panel">
-            <div className="leaderboard-panel__header">
-              <div>
-                <p className="section-label">의원 랭킹</p>
-                <h2>{`${currentAssemblyLabel} 의원 순위`}</h2>
-              </div>
-            </div>
-            <p className="leaderboard-panel__copy">
-              책임성 랭킹 데이터가 아직 준비되지 않았습니다.
-            </p>
-          </section>
-        )}
-
         <section className="search-panel">
           <div className="search-panel__layout">
             <div className="search-panel__command">
@@ -647,6 +627,26 @@ export default function App() {
             </ul>
           </div>
         </section>
+
+        {accountabilitySummary ? (
+          <AccountabilityLeaderboard
+            items={accountabilitySummary.items}
+            assemblyLabel={currentAssemblyLabel}
+            attendanceByMemberId={leaderboardAttendanceByMemberId}
+          />
+        ) : (
+          <section className="leaderboard-panel">
+            <div className="leaderboard-panel__header">
+              <div>
+                <p className="section-label">의원 랭킹</p>
+                <h2>{`${currentAssemblyLabel} 의원 순위`}</h2>
+              </div>
+            </div>
+            <p className="leaderboard-panel__copy">
+              책임성 랭킹 데이터가 아직 준비되지 않았습니다.
+            </p>
+          </section>
+        )}
 
         <footer className="info-panel">
           <p className="info-panel__body">

--- a/apps/web/src/styles/home-refresh.css
+++ b/apps/web/src/styles/home-refresh.css
@@ -16,6 +16,8 @@
 
 /* 공통 상단 강조선 — 인디고 그라디언트 */
 .hero-panel::before,
+.search-panel::before,
+.leaderboard-panel::before,
 .visualization-panel::before,
 .feed-panel::before,
 .info-panel::before {
@@ -25,17 +27,6 @@
   width: 100%;
   height: 0.2rem;
   background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 55%, transparent), transparent 70%);
-  pointer-events: none;
-}
-
-/* 리더보드 — 강렬한 적색 강조선, 데이터의 심각성 표현 */
-.leaderboard-panel::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto auto 0;
-  width: 100%;
-  height: 0.35rem;
-  background: linear-gradient(90deg, var(--negative) 0%, color-mix(in srgb, var(--negative) 30%, transparent) 60%, transparent 88%);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

- **리더보드 상단선 통일**: 붉은색 그라디언트 → 다른 패널과 동일한 인디고 악센트 그라디언트로 변경
- **검색 패널 상단선 추가**: 다른 패널과 동일한 인디고 강조선 적용
- **홈 섹션 순서 변경**: 검색 패널을 리더보드 위로 이동하여 action-first 레이아웃 구성

## Test plan

- [ ] `npm test` — 105개 전체 통과 확인
- [ ] 홈 화면에서 검색 패널이 리더보드 위에 표시되는지 확인
- [ ] 모든 패널 상단선이 인디고 계열로 통일되었는지 확인
- [ ] 검색 패널에 상단 인디고 강조선이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)