### PR TITLE
Retain public identifiers in analytics routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Web analytics settings:
 
 The web app does not load Google Analytics when the measurement ID is absent or
 invalid. When enabled, it records one page view for the initial screen and each
-distinct hash route, strips member and region identifiers from analytics URLs,
-disables advertising signals, and defaults all Consent Mode v2 storage settings
-to `denied`.
+distinct hash route, retains public member and region identifiers while dropping
+other hash parameters from analytics URLs, disables advertising signals, and
+defaults all Consent Mode v2 storage settings to `denied`.
 
 Public document mirror settings:
 

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -2,6 +2,11 @@ const GA_MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]+$/;
 const ANALYTICS_SCRIPT_ATTRIBUTE = "data-lawmaker-monitor-analytics";
 const ANALYTICS_CLEANUP_KEY = "__lawmakerMonitorAnalyticsCleanup";
 const CAMPAIGN_PARAMETER_PREFIX = "utm_";
+const ROUTE_IDENTIFIER_PARAMETERS: Record<string, readonly string[]> = {
+  calendar: ["member", "compare"],
+  distribution: ["member"],
+  map: ["district", "province"]
+};
 
 type GtagArguments = [command: string, ...parameters: unknown[]];
 type Gtag = (...args: GtagArguments) => void;
@@ -37,6 +42,26 @@ function getRouteName(url: URL): string {
   return url.hash.slice(1).split("?")[0]?.trim().toLowerCase() || "home";
 }
 
+function buildRouteIdentifierSearch(url: URL, routeName: string): string {
+  const searchStart = url.hash.indexOf("?");
+  if (searchStart < 0) {
+    return "";
+  }
+
+  const sourceParameters = new URLSearchParams(url.hash.slice(searchStart + 1));
+  const identifierParameters = new URLSearchParams();
+
+  for (const key of ROUTE_IDENTIFIER_PARAMETERS[routeName] ?? []) {
+    const value = sourceParameters.get(key)?.trim();
+    if (value) {
+      identifierParameters.set(key, value);
+    }
+  }
+
+  const search = identifierParameters.toString();
+  return search ? `?${search}` : "";
+}
+
 function buildCampaignSearch(searchParams: URLSearchParams): string {
   const campaignParameters = new URLSearchParams();
 
@@ -57,7 +82,9 @@ export function buildAnalyticsPage(
   const url = new URL(href);
   const normalizedDocumentTitle = documentTitle.trim() || "국회 출석부";
   const routeName = getRouteName(url);
-  const routeHash = routeName === "home" ? "" : `#${routeName}`;
+  const routeIdentifierSearch = buildRouteIdentifierSearch(url, routeName);
+  const routeHash =
+    routeName === "home" ? "" : `#${routeName}${routeIdentifierSearch}`;
   const campaignSearch = buildCampaignSearch(url.searchParams);
   const path = `${url.pathname}${campaignSearch}${routeHash}`;
   const routeTitle = ROUTE_TITLES[routeName];

--- a/tests/web/analytics.test.tsx
+++ b/tests/web/analytics.test.tsx
@@ -39,18 +39,33 @@ describe("Google Analytics integration", () => {
     expect(normalizeGaMeasurementId("")).toBeNull();
   });
 
-  it("groups traffic by public route without sending member identifiers", () => {
+  it("groups traffic by public route and preserves public member identifiers", () => {
     const page = buildAnalyticsPage(
-      "https://example.test/lawmaker-monitor/?ui=v2&deploy=abc&utm_source=social#calendar?member=SECRET",
+      "https://example.test/lawmaker-monitor/?ui=v2&deploy=abc&utm_source=social#calendar?member=M001&compare=M002&view=compare&note=SECRET",
       "국회 출석부"
     );
 
     expect(page).toEqual({
       location:
-        "https://example.test/lawmaker-monitor/?utm_source=social#calendar",
-      path: "/lawmaker-monitor/?utm_source=social#calendar",
+        "https://example.test/lawmaker-monitor/?utm_source=social#calendar?member=M001&compare=M002",
+      path: "/lawmaker-monitor/?utm_source=social#calendar?member=M001&compare=M002",
       title: "의원 활동 · 국회 출석부"
     });
+  });
+
+  it("preserves public district and province identifiers on map routes", () => {
+    expect(
+      buildAnalyticsPage(
+        "https://example.test/lawmaker-monitor/#map?district=%EC%84%9C%EC%9A%B8%EC%A4%91%EA%B5%AC&metric=negative"
+      ).path
+    ).toBe(
+      "/lawmaker-monitor/#map?district=%EC%84%9C%EC%9A%B8%EC%A4%91%EA%B5%AC"
+    );
+    expect(
+      buildAnalyticsPage(
+        "https://example.test/lawmaker-monitor/#map?province=%EB%B6%80%EC%82%B0&metric=assetTotal"
+      ).path
+    ).toBe("/lawmaker-monitor/#map?province=%EB%B6%80%EC%82%B0");
   });
 
   it("loads gtag with denied storage and records distinct hash routes", () => {
@@ -83,7 +98,7 @@ describe("Google Analytics integration", () => {
     ]);
     expect(getPageViewEvents()).toHaveLength(1);
     expect(getPageViewEvents()[0]?.[2]).toMatchObject({
-      page_path: "/lawmaker-monitor/#calendar",
+      page_path: "/lawmaker-monitor/#calendar?member=M001",
       page_title: "의원 활동 · 국회 출석부"
     });
 
@@ -94,7 +109,8 @@ describe("Google Analytics integration", () => {
     expect(getPageViewEvents()).toHaveLength(2);
     expect(getPageViewEvents()[1]?.[2]).toMatchObject({
       page_path: "/lawmaker-monitor/#votes",
-      page_referrer: "http://localhost:3000/lawmaker-monitor/#calendar",
+      page_referrer:
+        "http://localhost:3000/lawmaker-monitor/#calendar?member=M001",
       page_title: "쟁점·표결 · 국회 출석부"
     });
 


### PR DESCRIPTION
## Summary

- retain public member and comparison member identifiers in analytics page paths
- retain public district and province identifiers for map routes
- continue dropping unrelated hash parameters
- update analytics documentation and coverage

## Why

Public lawmaker and region identifiers are useful dimensions for understanding which public profiles and constituencies receive traffic.

## Validation

- `npm test -- --run tests/web/analytics.test.tsx`
- `npm run typecheck`
- ESLint and Prettier checks
- production web build