### PR TITLE
fix: quarantine incomplete vote records

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,6 +29,7 @@ jobs:
         run: npm run build --workspace @lawmaker-monitor/web
         env:
           VITE_DATA_REPO_BASE_URL: http://127.0.0.1:4174
+          SKIP_MEMBER_SHARE_GENERATION: "1"
 
       - name: Run lint
         run: npm run lint

--- a/apps/web/src/components/ActivityCalendarPage.tsx
+++ b/apps/web/src/components/ActivityCalendarPage.tsx
@@ -134,7 +134,7 @@ const weekdayLabels = ["일", "월", "화", "수", "목", "금", "토"];
 const currentRunLabel = "현재 찬성 없이 이어진 날";
 const longestRunLabel = "가장 길게 찬성 없이 이어진 날";
 const runSummaryCopy =
-  "참여율은 의원 재임 기간에 공개된 기록표결을 기준으로 계산합니다. 찬성·반대·기권은 참여로, 불참은 별도로 표시합니다. 정당 비교는 공식 당론이 아니라 같은 정당 참여 의원 다수와의 차이입니다.";
+  "확인된 참여율은 의원 재임 기간에 공개된 기록표결 중 의원별 표결행을 확인한 건만 기준으로 계산합니다. 찬성·반대·기권은 참여로, 불참과 확인 불가는 별도로 표시합니다. 정당 비교는 공식 당론이 아니라 같은 정당 참여 의원 다수와의 차이입니다.";
 
 function describeDebtRatioStatus(status: DebtRatioStatus): string {
   switch (status) {
@@ -253,7 +253,8 @@ function buildRatioData(member: MemberActivityCalendarMember): RatioDatum[] {
     breakdown.yesDays +
     breakdown.noDays +
     breakdown.abstainDays +
-    breakdown.absentDays;
+    breakdown.absentDays +
+    breakdown.unknownDays;
 
   const toPercent = (value: number): number =>
     total === 0 ? 0 : Math.round((value / total) * 100);
@@ -278,6 +279,11 @@ function buildRatioData(member: MemberActivityCalendarMember): RatioDatum[] {
       label: "불참",
       percent: toPercent(breakdown.absentDays),
       color: "var(--vote-absent)"
+    },
+    {
+      label: "확인 불가",
+      percent: toPercent(breakdown.unknownDays),
+      color: "var(--ink-muted)"
     }
   ];
 }
@@ -289,7 +295,8 @@ function renderRatioAxisTick({ x = 0, y = 0, payload }: RatioTickProps) {
       찬성: "var(--vote-yes)",
       반대: "var(--vote-no)",
       기권: "var(--vote-abstain)",
-      불참: "var(--vote-absent)"
+      불참: "var(--vote-absent)",
+      "확인 불가": "var(--ink-muted)"
     }[label] ?? "var(--ink-muted)";
 
   return (
@@ -1602,10 +1609,13 @@ function ActivityRatioChart({
   const data = buildRatioData(member);
 
   return (
-    <section className="activity-ratio-card" aria-label="활동 비율">
+    <section
+      className="activity-ratio-card"
+      aria-label="일별 대표 표결 상태 비율"
+    >
       <div className="activity-ratio-card__header">
-        <h4>활동 비율</h4>
-        <p>캘린더 날짜 기준 비율</p>
+        <h4>일별 대표 표결 상태 비율</h4>
+        <p>본회의 출석률이 아닌 공개 기록표결 기준</p>
       </div>
       <div className="activity-ratio-card__body">
         <div className="activity-ratio-card__chart">
@@ -1667,11 +1677,11 @@ function ActivityCompareRatioChart({
   return (
     <section
       className="activity-ratio-card activity-ratio-card--compare"
-      aria-label="비율 비교"
+      aria-label="일별 대표 표결 상태 비율 비교"
     >
       <div className="activity-ratio-card__header">
-        <h4>비율 비교</h4>
-        <p>캘린더 날짜 기준 비율</p>
+        <h4>일별 대표 표결 상태 비율 비교</h4>
+        <p>본회의 출석률이 아닌 공개 기록표결 기준</p>
       </div>
       <div className="activity-ratio-compare__legend">
         <div className="activity-ratio-compare__legend-item activity-ratio-compare__legend-item--left">
@@ -1728,7 +1738,7 @@ function ActivityCompareRatioChart({
         <div
           className="activity-ratio-compare__table"
           role="table"
-          aria-label="비율 비교 표"
+          aria-label="일별 대표 표결 상태 비율 비교 표"
         >
           <div
             className="activity-ratio-compare__row activity-ratio-compare__row--head"
@@ -1828,6 +1838,11 @@ function ActivityVoteRecordSections({
       voteCode: "absent",
       label: "불참",
       records: records.filter((record) => record.voteCode === "absent")
+    },
+    {
+      voteCode: "unknown",
+      label: "확인 불가",
+      records: records.filter((record) => record.voteCode === "unknown")
     }
   ];
   const groupedRecords: Array<{
@@ -2007,8 +2022,29 @@ function ActivityCommitteeSections({
 }: {
   member: MemberActivityCalendarMember;
 }) {
-  const committeeSummaries = (member.committeeSummaries ?? []).filter(
-    (summary) => summary.eligibleRollCallCount >= 5
+  const committeeSummaries = (member.committeeSummaries ?? [])
+    .filter((summary) => summary.eligibleRollCallCount >= 5)
+    .map((summary) => {
+      const resolvedRollCallCount = Math.max(
+        0,
+        summary.eligibleRollCallCount - (summary.unresolvedRollCallCount ?? 0)
+      );
+      return {
+        ...summary,
+        resolvedRollCallCount,
+        confirmedParticipationRate:
+          resolvedRollCallCount > 0
+            ? summary.participatedRollCallCount / resolvedRollCallCount
+            : null
+      };
+    });
+  const comparableCommitteeSummaries = committeeSummaries.filter(
+    (summary) =>
+      summary.resolvedRollCallCount >= 5 &&
+      summary.confirmedParticipationRate !== null
+  );
+  const unavailableCommitteeSummaries = committeeSummaries.filter(
+    (summary) => summary.resolvedRollCallCount < 5
   );
   const [expandedSections, setExpandedSections] = useState<
     Record<string, boolean>
@@ -2018,10 +2054,15 @@ function ActivityCommitteeSections({
     return null;
   }
 
-  const mostResponsiveCommittees = [...committeeSummaries].sort(
+  const mostResponsiveCommittees = [...comparableCommitteeSummaries].sort(
     (left, right) => {
-      if (right.participationRate !== left.participationRate) {
-        return right.participationRate - left.participationRate;
+      if (
+        right.confirmedParticipationRate !== left.confirmedParticipationRate
+      ) {
+        return (
+          (right.confirmedParticipationRate ?? 0) -
+          (left.confirmedParticipationRate ?? 0)
+        );
       }
 
       if (right.eligibleRollCallCount !== left.eligibleRollCallCount) {
@@ -2031,10 +2072,15 @@ function ActivityCommitteeSections({
       return left.committeeName.localeCompare(right.committeeName, "ko-KR");
     }
   );
-  const leastResponsiveCommittees = [...committeeSummaries].sort(
+  const leastResponsiveCommittees = [...comparableCommitteeSummaries].sort(
     (left, right) => {
-      if (left.participationRate !== right.participationRate) {
-        return left.participationRate - right.participationRate;
+      if (
+        left.confirmedParticipationRate !== right.confirmedParticipationRate
+      ) {
+        return (
+          (left.confirmedParticipationRate ?? 0) -
+          (right.confirmedParticipationRate ?? 0)
+        );
       }
 
       if (right.eligibleRollCallCount !== left.eligibleRollCallCount) {
@@ -2048,28 +2094,37 @@ function ActivityCommitteeSections({
   const sections = [
     {
       id: "most-responsive",
-      title: "관심 높은 위원회",
-      description: "참여율 높은 순",
+      title: "확인된 소관 안건 참여율 높은 위원회",
+      description: "확인된 본회의 기록표결 참여율 높은 순",
       summaries: mostResponsiveCommittees
     },
     {
       id: "least-responsive",
-      title: "무관심한 위원회",
-      description: "참여율 낮은 순",
+      title: "확인된 소관 안건 참여율 낮은 위원회",
+      description: "확인된 본회의 기록표결 참여율 낮은 순",
       summaries: leastResponsiveCommittees
+    },
+    {
+      id: "unavailable",
+      title: "표결행 확인 부족",
+      description: "확인된 기록표결 5건 미만 · 참여율 순위 제외",
+      summaries: unavailableCommitteeSummaries
     }
-  ];
+  ].filter((section) => section.summaries.length > 0);
   const visibleCommitteeCount = Math.min(
     INITIAL_VISIBLE_COMMITTEE_COUNT,
-    committeeSummaries.length
+    comparableCommitteeSummaries.length
   );
 
   return (
-    <section className="activity-committee-sections" aria-label="위원회 반응도">
+    <section
+      className="activity-committee-sections"
+      aria-label="위원회 소관 안건 본회의 확인된 표결 참여율"
+    >
       <div className="activity-committee-sections__header">
-        <h4>위원회 반응도</h4>
+        <h4>위원회 소관 안건 본회의 확인된 표결 참여율</h4>
         <p>
-          {`대상 표결 5건 이상 위원회 ${formatNumber(committeeSummaries.length)}곳 중 상위·하위 ${formatNumber(visibleCommitteeCount)}곳만 먼저 보여주고, 나머지는 필요할 때 펼칩니다.`}
+          {`실제 위원회 출석률이 아니라, 해당 위원회가 소관한 본회의 기록표결 기준입니다. 전체 대상 5건 이상 ${formatNumber(committeeSummaries.length)}곳 중 표결행이 5건 이상 확인된 ${formatNumber(comparableCommitteeSummaries.length)}곳을 비교하며, 상위·하위 ${formatNumber(visibleCommitteeCount)}곳만 먼저 보여줍니다.`}
         </p>
       </div>
       <div className="activity-committee-sections__groups">
@@ -2116,10 +2171,18 @@ function ActivityCommitteeSections({
                               </span>
                             ) : null}
                           </div>
-                          <strong>{`${formatNumber(Math.round(summary.participationRate * 100))}%`}</strong>
+                          <strong>
+                            {summary.confirmedParticipationRate === null
+                              ? "산정 불가"
+                              : `${formatNumber(
+                                  Math.round(
+                                    summary.confirmedParticipationRate * 100
+                                  )
+                                )}%`}
+                          </strong>
                         </div>
                         <p className="activity-committee-card__meta">
-                          {`참여 ${formatNumber(summary.participatedRollCallCount)} / 대상 ${formatNumber(summary.eligibleRollCallCount)} · 불참 ${formatNumber(summary.absentRollCallCount)}`}
+                          {`확인된 참여 ${formatNumber(summary.participatedRollCallCount)} / 확인된 표결 ${formatNumber(summary.resolvedRollCallCount)} · 전체 대상 ${formatNumber(summary.eligibleRollCallCount)} · 명시 불참 ${formatNumber(summary.absentRollCallCount)} · 확인 불가 ${formatNumber(summary.unresolvedRollCallCount ?? 0)}`}
                         </p>
                         <div
                           className="activity-committee-card__bar"

--- a/apps/web/src/components/ChangeDocket.tsx
+++ b/apps/web/src/components/ChangeDocket.tsx
@@ -71,7 +71,7 @@ const statusMeta: Record<
   },
   unobserved: {
     label: "관측 대기",
-    shortLabel: "대기",
+    shortLabel: "관측 대기",
     description: "두 구간을 비교할 공개 표결 기록이 충분하지 않습니다."
   }
 };
@@ -148,22 +148,27 @@ function buildDocketItems(
         return [];
       }
 
-      const previousRate = mover
-        ? getRate({
-            noCount: mover.previousWindowNoCount,
-            abstainCount: mover.previousWindowAbstainCount,
-            absentCount: mover.previousWindowAbsentCount,
-            eligibleCount: mover.previousWindowEligibleCount
-          })
-        : null;
-      const currentRate = mover
-        ? getRate({
-            noCount: mover.currentWindowNoCount,
-            abstainCount: mover.currentWindowAbstainCount,
-            absentCount: mover.currentWindowAbsentCount,
-            eligibleCount: mover.currentWindowEligibleCount
-          })
-        : null;
+      const hasUnresolvedWindow =
+        (mover?.previousWindowUnresolvedCount ?? 0) > 0 ||
+        (mover?.currentWindowUnresolvedCount ?? 0) > 0;
+      const previousRate =
+        mover && !hasUnresolvedWindow
+          ? getRate({
+              noCount: mover.previousWindowNoCount,
+              abstainCount: mover.previousWindowAbstainCount,
+              absentCount: mover.previousWindowAbsentCount,
+              eligibleCount: mover.previousWindowEligibleCount
+            })
+          : null;
+      const currentRate =
+        mover && !hasUnresolvedWindow
+          ? getRate({
+              noCount: mover.currentWindowNoCount,
+              abstainCount: mover.currentWindowAbstainCount,
+              absentCount: mover.currentWindowAbsentCount,
+              eligibleCount: mover.currentWindowEligibleCount
+            })
+          : null;
       const delta =
         previousRate === null || currentRate === null
           ? null
@@ -400,7 +405,7 @@ export function ChangeDocket({
                 ) : (
                   <div className="change-docket__unobserved-value">
                     <dt>표결 비교</dt>
-                    <dd>관측 대기</dd>
+                    <dd>확인 불가</dd>
                   </div>
                 )}
               </dl>

--- a/apps/web/src/components/DistributionPage.tsx
+++ b/apps/web/src/components/DistributionPage.tsx
@@ -86,6 +86,13 @@ function formatPercentPointDelta(value: number): string {
   return `평균 대비 ${prefix}${Math.abs(value * 100).toFixed(1)}%p`;
 }
 
+function formatKnownVoteRate(
+  member: DistributionMemberPoint,
+  value: number
+): string {
+  return member.participationRateAvailable ? formatPercent(value) : "산정 불가";
+}
+
 function buildPartyColorMap(
   members: DistributionMemberPoint[]
 ): Map<string, string> {
@@ -97,15 +104,17 @@ function buildPartyColorMap(
 function buildChartPoints(
   members: DistributionMemberPoint[]
 ): DistributionChartPoint[] {
-  return members.map((member) => ({
-    ...member,
-    attendancePercent: Number((member.attendanceRate * 100).toFixed(1)),
-    negativePercent: Number((member.negativeRate * 100).toFixed(1)),
-    radius:
-      7 +
-      Math.min(member.currentNegativeOrAbsentStreak, 4) +
-      Math.min(member.absentVoteCount, 3)
-  }));
+  return members
+    .filter((member) => member.participationRateAvailable)
+    .map((member) => ({
+      ...member,
+      attendancePercent: Number((member.attendanceRate * 100).toFixed(1)),
+      negativePercent: Number((member.negativeRate * 100).toFixed(1)),
+      radius:
+        7 +
+        Math.min(member.currentNegativeOrAbsentStreak, 4) +
+        Math.min(member.absentVoteCount, 3)
+    }));
 }
 
 function useDistributionPointPhoto(photoUrl?: string | null): boolean {
@@ -297,7 +306,7 @@ function DistributionTooltipPanel({ active, payload }: TooltipProps) {
       }`}</p>
       <ul>
         <li>
-          <span>출석률</span>
+          <span>확인된 표결 참여율</span>
           <strong>{formatPercent(point.attendanceRate)}</strong>
         </li>
         <li>
@@ -416,6 +425,13 @@ export function DistributionPage({
     () => filterDistributionMembersByBehavior(members, activeBehaviorFilter),
     [activeBehaviorFilter, members]
   );
+  const comparableBehaviorMembers = useMemo(
+    () =>
+      behaviorFilteredMembers.filter(
+        (member) => member.participationRateAvailable
+      ),
+    [behaviorFilteredMembers]
+  );
   const partySummaries = useMemo(
     () => buildDistributionPartySummaries(behaviorFilteredMembers),
     [behaviorFilteredMembers]
@@ -484,20 +500,20 @@ export function DistributionPage({
     partySummaries.find((summary) => summary.party === activePartyFilter) ??
     null;
   const averageAttendanceRate =
-    behaviorFilteredMembers.length > 0
-      ? behaviorFilteredMembers.reduce(
+    comparableBehaviorMembers.length > 0
+      ? comparableBehaviorMembers.reduce(
           (sum, member) => sum + member.attendanceRate,
           0
-        ) / behaviorFilteredMembers.length
+        ) / comparableBehaviorMembers.length
       : 0;
   const averageNegativeRate =
-    behaviorFilteredMembers.length > 0
-      ? behaviorFilteredMembers.reduce(
+    comparableBehaviorMembers.length > 0
+      ? comparableBehaviorMembers.reduce(
           (sum, member) => sum + member.negativeRate,
           0
-        ) / behaviorFilteredMembers.length
+        ) / comparableBehaviorMembers.length
       : 0;
-  const highNegativeMembers = [...behaviorFilteredMembers]
+  const highNegativeMembers = [...comparableBehaviorMembers]
     .sort((left, right) => {
       if (right.negativeRate !== left.negativeRate) {
         return right.negativeRate - left.negativeRate;
@@ -512,7 +528,7 @@ export function DistributionPage({
       );
     })
     .slice(0, 5);
-  const attendanceRiskMembers = [...behaviorFilteredMembers]
+  const attendanceRiskMembers = [...comparableBehaviorMembers]
     .sort((left, right) => {
       if (left.attendanceRate !== right.attendanceRate) {
         return left.attendanceRate - right.attendanceRate;
@@ -605,7 +621,7 @@ export function DistributionPage({
 
   const chartHeading = activeBehaviorSummary
     ? `${activeBehaviorSummary.label} 의원을 먼저 보고 있습니다.`
-    : "위로 갈수록 반대·기권 비중이 낮고, 오른쪽으로 갈수록 출석률이 높습니다.";
+    : "위로 갈수록 반대·기권 비중이 낮고, 오른쪽으로 갈수록 재임 누적 표결 참여율이 높습니다.";
   const chartSearchNote = activeBehaviorSummary
     ? `${activeBehaviorSummary.label} 분류가 적용되어 ${formatNumber(behaviorFilteredMembers.length)}명만 먼저 보고 있습니다. 다른 의원을 직접 고르면 분류는 해제됩니다.`
     : activePartyFilter
@@ -770,12 +786,13 @@ export function DistributionPage({
                     role="note"
                   >
                     <p className="distribution-page__copy">
-                      출석률과 반대·기권 비중을 한 좌표에 두고, 불참과 연속
-                      패턴을 함께 읽는 첫 분포 화면입니다.
+                      확인된 재임 누적 표결 참여율과 반대·기권 비중을 한 좌표에
+                      두고, 불참과 일별 연속 패턴을 함께 읽는 분포 화면입니다.
                     </p>
                     <p className="distribution-chart__copy">
-                      가로축은 출석률, 세로축은 반대·기권 비중이며 값이 낮을수록
-                      위로 올라갑니다. 점 크기는 현재 반대·기권·불참 연속 패턴을
+                      가로축은 의원별 응답이 확인된 기록표결만 사용합니다.
+                      의원별 표결행을 확인할 수 없는 경우에는 산정과 순위에서
+                      제외하며, 점 크기만 일별 대표 상태의 현재 연속 패턴을
                       반영합니다.
                     </p>
                     <p className="distribution-page__search-note">
@@ -794,13 +811,21 @@ export function DistributionPage({
                   <small>{filterScopeText}</small>
                 </div>
                 <div className="chart-card__summary">
-                  <span>평균 출석률</span>
-                  <strong>{formatPercent(averageAttendanceRate)}</strong>
-                  <small>캘린더 날짜 기준</small>
+                  <span>의원별 확인된 참여율 단순평균</span>
+                  <strong>
+                    {comparableBehaviorMembers.length > 0
+                      ? formatPercent(averageAttendanceRate)
+                      : "산정 불가"}
+                  </strong>
+                  <small>{`의원별 표결행 확인 ${formatNumber(comparableBehaviorMembers.length)}명 기준`}</small>
                 </div>
                 <div className="chart-card__summary">
                   <span>평균 반대·기권 비중</span>
-                  <strong>{formatPercent(averageNegativeRate)}</strong>
+                  <strong>
+                    {comparableBehaviorMembers.length > 0
+                      ? formatPercent(averageNegativeRate)
+                      : "산정 불가"}
+                  </strong>
                   <small>
                     {activeBehaviorSummary
                       ? "행동 분류 기준"
@@ -817,16 +842,20 @@ export function DistributionPage({
                   margin={{ top: 22, right: 28, bottom: 34, left: 12 }}
                 >
                   <CartesianGrid stroke="rgba(72, 56, 40, 0.12)" />
-                  <ReferenceLine
-                    x={Number((averageAttendanceRate * 100).toFixed(1))}
-                    stroke="rgba(91, 108, 0, 0.22)"
-                    strokeDasharray="4 4"
-                  />
-                  <ReferenceLine
-                    y={Number((averageNegativeRate * 100).toFixed(1))}
-                    stroke="rgba(91, 108, 0, 0.22)"
-                    strokeDasharray="4 4"
-                  />
+                  {comparableBehaviorMembers.length > 0 ? (
+                    <>
+                      <ReferenceLine
+                        x={Number((averageAttendanceRate * 100).toFixed(1))}
+                        stroke="rgba(91, 108, 0, 0.22)"
+                        strokeDasharray="4 4"
+                      />
+                      <ReferenceLine
+                        y={Number((averageNegativeRate * 100).toFixed(1))}
+                        stroke="rgba(91, 108, 0, 0.22)"
+                        strokeDasharray="4 4"
+                      />
+                    </>
+                  ) : null}
                   <XAxis
                     type="number"
                     dataKey="attendancePercent"
@@ -834,7 +863,7 @@ export function DistributionPage({
                     tick={{ fill: "rgba(29, 24, 18, 0.72)", fontSize: 12 }}
                     tickFormatter={(value) => `${value}%`}
                     label={{
-                      value: "출석률",
+                      value: "확인된 표결 참여율",
                       position: "insideBottom",
                       offset: -12
                     }}
@@ -979,27 +1008,46 @@ export function DistributionPage({
 
             <div className="distribution-focus__metric-grid">
               <article className="distribution-focus__metric">
-                <span>출석률</span>
-                <strong>{formatPercent(selectedMember.attendanceRate)}</strong>
+                <span>확인된 표결 참여율</span>
+                <strong>
+                  {selectedMember.participationRateAvailable
+                    ? formatPercent(selectedMember.attendanceRate)
+                    : "산정 불가"}
+                </strong>
                 <small>
-                  {`${formatNumber(selectedMember.attendedDays)}일 / 대상 ${formatNumber(
-                    selectedMember.eligibleDays
-                  )}일`}
+                  {`확인된 참여 ${formatNumber(selectedMember.participatedRollCallCount)}건 / 확인된 표결 ${formatNumber(
+                    selectedMember.resolvedRollCallCount
+                  )}건 · 전체 대상 ${formatNumber(
+                    selectedMember.eligibleRollCallCount
+                  )}건 · 확인 불가 ${formatNumber(
+                    selectedMember.unresolvedRollCallCount
+                  )}건`}
                 </small>
               </article>
               <article className="distribution-focus__metric distribution-focus__metric--alert">
                 <span>반대·기권 비중</span>
-                <strong>{formatPercent(selectedMember.negativeRate)}</strong>
+                <strong>
+                  {selectedMember.participationRateAvailable
+                    ? formatPercent(selectedMember.negativeRate)
+                    : "산정 불가"}
+                </strong>
                 <small>
-                  {formatPercentPointDelta(
-                    selectedMember.negativeRate - averageNegativeRate
-                  )}
+                  {selectedMember.participationRateAvailable &&
+                  comparableBehaviorMembers.length > 0
+                    ? formatPercentPointDelta(
+                        selectedMember.negativeRate - averageNegativeRate
+                      )
+                    : "의원별 표결행을 확인할 수 없습니다."}
                 </small>
               </article>
               <article className="distribution-focus__metric distribution-focus__metric--absence">
                 <span>불참 비중</span>
-                <strong>{formatPercent(selectedMember.absentRate)}</strong>
-                <small>{`${formatNumber(selectedMember.absentVoteCount)}건 불참`}</small>
+                <strong>
+                  {selectedMember.participationRateAvailable
+                    ? formatPercent(selectedMember.absentRate)
+                    : "산정 불가"}
+                </strong>
+                <small>{`${formatNumber(selectedMember.absentVoteCount)}건 명시 불참`}</small>
               </article>
               <article className="distribution-focus__metric">
                 <span>현재 연속 패턴</span>
@@ -1033,19 +1081,33 @@ export function DistributionPage({
               <div className="distribution-focus__composition-list">
                 <span>
                   <i className="distribution-focus__dot distribution-focus__dot--yes" />
-                  찬성 {formatPercent(selectedMember.yesRate)}
+                  찬성{" "}
+                  {formatKnownVoteRate(selectedMember, selectedMember.yesRate)}
                 </span>
                 <span>
                   <i className="distribution-focus__dot distribution-focus__dot--no" />
-                  반대 {formatPercent(selectedMember.noRate)}
+                  반대{" "}
+                  {formatKnownVoteRate(selectedMember, selectedMember.noRate)}
                 </span>
                 <span>
                   <i className="distribution-focus__dot distribution-focus__dot--abstain" />
-                  기권 {formatPercent(selectedMember.abstainRate)}
+                  기권{" "}
+                  {formatKnownVoteRate(
+                    selectedMember,
+                    selectedMember.abstainRate
+                  )}
                 </span>
                 <span>
                   <i className="distribution-focus__dot distribution-focus__dot--absent" />
-                  불참 {formatPercent(selectedMember.absentRate)}
+                  불참{" "}
+                  {formatKnownVoteRate(
+                    selectedMember,
+                    selectedMember.absentRate
+                  )}
+                </span>
+                <span>
+                  확인 불가{" "}
+                  {formatNumber(selectedMember.unresolvedRollCallCount)}건
                 </span>
               </div>
             </div>
@@ -1068,11 +1130,14 @@ export function DistributionPage({
                 <dd>{`${formatNumber(selectedMember.absentDayCount)}일`}</dd>
               </div>
               <div>
-                <dt>출석률 위치</dt>
+                <dt>확인된 참여율 위치</dt>
                 <dd>
-                  {formatPercentPointDelta(
-                    selectedMember.attendanceRate - averageAttendanceRate
-                  )}
+                  {selectedMember.participationRateAvailable &&
+                  comparableBehaviorMembers.length > 0
+                    ? formatPercentPointDelta(
+                        selectedMember.attendanceRate - averageAttendanceRate
+                      )
+                    : "산정 불가"}
                 </dd>
               </div>
             </dl>
@@ -1091,7 +1156,7 @@ export function DistributionPage({
         />
         <DistributionSignalList
           title="시그널 2"
-          description="출석률이 낮은 의원"
+          description="확인된 재임 누적 표결 참여율이 낮은 의원"
           members={attendanceRiskMembers}
           selectedMemberId={selectedMemberId}
           onSelectMember={handleSelectMember}
@@ -1148,7 +1213,12 @@ export function DistributionPage({
                     <strong>{`${formatNumber(summary.memberCount)}명`}</strong>
                   </div>
                   <div className="distribution-party-list__stats">
-                    <span>{`평균 출석률 ${formatPercent(summary.averageAttendanceRate)}`}</span>
+                    <span>
+                      {summary.comparableMemberCount > 0
+                        ? `평균 확인된 참여율 ${formatPercent(summary.averageAttendanceRate)}`
+                        : "평균 확인된 참여율 산정 불가"}
+                    </span>
+                    <span>{`표결행 확인 ${formatNumber(summary.comparableMemberCount)} / ${formatNumber(summary.memberCount)}명`}</span>
                     <span>{`평균 반대·기권 ${formatPercent(summary.averageNegativeRate)}`}</span>
                     <span>{`평균 불참 ${formatPercent(summary.averageAbsenceRate)}`}</span>
                     <span>{`최대 연속 ${formatNumber(summary.topCurrentStreak)}일`}</span>

--- a/apps/web/src/components/HexmapPage.tsx
+++ b/apps/web/src/components/HexmapPage.tsx
@@ -67,8 +67,8 @@ const METRIC_CONFIGS: Array<{
 }> = [
   {
     key: "absence",
-    label: "결석률",
-    shortLabel: "결석률",
+    label: "표결 불참률",
+    shortLabel: "불참률",
     basis: "본회의 기준",
     description: "공개된 본회의 표결 중 결석으로 기록된 비율"
   },
@@ -108,6 +108,7 @@ type RegionalMember = {
   photoUrl: string | null;
   absentRate: number;
   negativeRate: number;
+  voteMetricsAvailable: boolean;
   realEstateTotal: number | null;
   assetTotal: number | null;
   assemblyNo: number;
@@ -199,9 +200,9 @@ function getMetricValue(
 ): number | null {
   switch (metric) {
     case "absence":
-      return member.absentRate;
+      return member.voteMetricsAvailable ? member.absentRate : null;
     case "negative":
-      return member.negativeRate;
+      return member.voteMetricsAvailable ? member.negativeRate : null;
     case "realEstate":
       return member.realEstateTotal;
     case "assetTotal":
@@ -383,6 +384,10 @@ export function HexmapPage({
         const province = getProvinceFromDistrict(sourceDistrict);
         const district = normalizeDistrictLabel(sourceDistrict, province);
         const assets = assetsByMemberId.get(item.memberId);
+        const resolvedVoteCount = Math.max(
+          0,
+          item.totalRecordedVotes - (item.unresolvedCount ?? 0)
+        );
         return {
           memberId: item.memberId,
           name: item.name,
@@ -391,8 +396,13 @@ export function HexmapPage({
           province,
           districtGroup: getDistrictGroup(district, province),
           photoUrl: getOptimizedMemberPhotoUrl(item.photoUrl),
-          absentRate: item.absentRate,
-          negativeRate: item.noRate + item.abstainRate,
+          absentRate:
+            resolvedVoteCount > 0 ? item.absentCount / resolvedVoteCount : 0,
+          negativeRate:
+            resolvedVoteCount > 0
+              ? (item.noCount + item.abstainCount) / resolvedVoteCount
+              : 0,
+          voteMetricsAvailable: resolvedVoteCount > 0,
           realEstateTotal: assets?.realEstateTotal ?? null,
           assetTotal: assets?.assetTotal ?? null,
           assemblyNo: item.assemblyNo,

--- a/apps/web/src/components/MemberEvaluationDossier.tsx
+++ b/apps/web/src/components/MemberEvaluationDossier.tsx
@@ -14,6 +14,7 @@ import { WarningDiamondIcon } from "@phosphor-icons/react/dist/csr/WarningDiamon
 import { useMemo, useState } from "react";
 
 import { MemberIdentity } from "./MemberIdentity.js";
+import { buildParticipationSnapshot } from "../lib/accountability.js";
 import {
   formatAssetEok,
   formatAssetEokDelta,
@@ -366,32 +367,60 @@ export function MemberEvaluationDossier({
   const latestAssetPoint = assetSeries.at(-1) ?? null;
   const previousAssetPoint =
     assetSeries.length >= 2 ? (assetSeries.at(-2) ?? null) : null;
-  const participatedVoteCount = accountabilityItem
-    ? Math.max(
-        0,
-        accountabilityItem.totalRecordedVotes - accountabilityItem.absentCount
+  const participationSnapshot = accountabilityItem
+    ? buildParticipationSnapshot(
+        accountabilityItem.totalRecordedVotes,
+        accountabilityItem.absentCount,
+        accountabilityItem.unresolvedCount ?? 0
       )
     : null;
 
   const confirmedItems = useMemo<EvidenceItem[]>(() => {
     const items: EvidenceItem[] = [];
-    if (accountabilityItem && participatedVoteCount !== null) {
+    if (
+      accountabilityItem &&
+      participationSnapshot &&
+      participationSnapshot.rate !== null
+    ) {
       items.push({
         id: "plenary-participation",
-        label: "공개 기록표결 참여율",
+        label: "확인된 공개 기록표결 참여율",
         value: formatRatio(
-          participatedVoteCount,
-          accountabilityItem.totalRecordedVotes,
+          participationSnapshot.participatedCount,
+          participationSnapshot.resolvedCount,
           "산정 가능한 기록표결 없음"
         ),
         detail: `관찰 기간 ${formatDate(assembly.startDate)} – ${observationDate}`,
-        status: "분모: 의원별 참여 대상 공개 기록표결",
+        status: `확인된 표결 ${formatNumber(
+          participationSnapshot.resolvedCount
+        )}건 / 전체 대상 ${formatNumber(
+          participationSnapshot.eligibleCount
+        )}건 · 확인 불가 ${formatNumber(
+          participationSnapshot.unresolvedCount
+        )}건`,
+        href: "#member-votes"
+      });
+    } else if (
+      accountabilityItem &&
+      participationSnapshot &&
+      participationSnapshot.eligibleCount > 0
+    ) {
+      items.push({
+        id: "plenary-participation-unresolved",
+        label: "확인된 공개 기록표결 참여율",
+        value: "산정 불가",
+        detail: `${formatNumber(
+          participationSnapshot.eligibleCount
+        )}건 모두 의원별 표결행을 확인할 수 없습니다.`,
+        status: `확인 불가 ${formatNumber(
+          participationSnapshot.unresolvedCount
+        )}건 · 불참으로 추론하지 않음`,
         href: "#member-votes"
       });
     } else {
       items.push({
         id: "plenary-participation-missing",
-        label: "공개 기록표결 참여율",
+        label: "확인된 공개 기록표결 참여율",
         value: "집계 자료 없음",
         detail: `${assembly.label} 참여 분모와 건수를 확인할 수 없습니다.`,
         status: "데이터 상태: 미확인"
@@ -453,11 +482,11 @@ export function MemberEvaluationDossier({
     billItem,
     committeeNames,
     observationDate,
-    participatedVoteCount
+    participationSnapshot
   ]);
 
   const reviewItems = useMemo<EvidenceItem[]>(() => {
-    if (!accountabilityItem) {
+    if (!accountabilityItem || !participationSnapshot) {
       return [
         {
           id: "review-missing",
@@ -469,48 +498,43 @@ export function MemberEvaluationDossier({
       ];
     }
 
+    const reviewValue = (count: number): string =>
+      participationSnapshot.resolvedCount > 0
+        ? formatRatio(
+            count,
+            participationSnapshot.resolvedCount,
+            "산정 가능한 기록표결 없음"
+          )
+        : "산정 불가";
+    const reviewStatus = `확인된 표결 ${formatNumber(
+      participationSnapshot.resolvedCount
+    )}건 / 전체 대상 ${formatNumber(
+      participationSnapshot.eligibleCount
+    )}건 · 확인 불가 ${formatNumber(participationSnapshot.unresolvedCount)}건`;
     const items: EvidenceItem[] = [
       {
         id: "absence",
         label: "본회의 기록표결 불참",
-        value: formatRatio(
-          accountabilityItem.absentCount,
-          accountabilityItem.totalRecordedVotes,
-          "산정 가능한 기록표결 없음"
-        ),
+        value: reviewValue(accountabilityItem.absentCount),
         detail:
           "불참 사유는 표결 기록만으로 알 수 없어 원문·공식 설명 확인이 필요합니다.",
-        status: `분모: 기록표결 ${formatNumber(
-          accountabilityItem.totalRecordedVotes
-        )}건`,
+        status: reviewStatus,
         href: "#member-votes"
       },
       {
         id: "no-votes",
         label: "반대 표결",
-        value: formatRatio(
-          accountabilityItem.noCount,
-          accountabilityItem.totalRecordedVotes,
-          "산정 가능한 기록표결 없음"
-        ),
+        value: reviewValue(accountabilityItem.noCount),
         detail: "반대 여부는 의안별 판단 기록이며 평가 점수가 아닙니다.",
-        status: `분모: 기록표결 ${formatNumber(
-          accountabilityItem.totalRecordedVotes
-        )}건`,
+        status: reviewStatus,
         href: "#member-votes"
       },
       {
         id: "abstain-votes",
         label: "기권 표결",
-        value: formatRatio(
-          accountabilityItem.abstainCount,
-          accountabilityItem.totalRecordedVotes,
-          "산정 가능한 기록표결 없음"
-        ),
+        value: reviewValue(accountabilityItem.abstainCount),
         detail: "기권 여부도 의안별 판단 기록이며 평가 점수가 아닙니다.",
-        status: `분모: 기록표결 ${formatNumber(
-          accountabilityItem.totalRecordedVotes
-        )}건`,
+        status: reviewStatus,
         href: "#member-votes"
       }
     ];
@@ -533,7 +557,7 @@ export function MemberEvaluationDossier({
     }
 
     return items;
-  }, [accountabilityItem]);
+  }, [accountabilityItem, participationSnapshot]);
 
   const holdItems = useMemo<EvidenceItem[]>(() => {
     const items: EvidenceItem[] = [];

--- a/apps/web/src/components/VisualizationOverview.tsx
+++ b/apps/web/src/components/VisualizationOverview.tsx
@@ -37,6 +37,7 @@ const chartPalette = {
   no: "#34362e",
   abstain: "#c58512",
   absent: "var(--absence)",
+  unresolved: "#7d7468",
   partyLine: "#2457a6",
   grid: "#dfe5ec",
   axis: "#667085",
@@ -61,6 +62,7 @@ function WeeklyTrendTooltipPanel({ active, payload }: TooltipProps) {
         noCount: number;
         abstainCount: number;
         absentCount: number;
+        unresolvedCount: number;
         eligibleVoteCount: number;
       }
     | undefined;
@@ -89,6 +91,10 @@ function WeeklyTrendTooltipPanel({ active, payload }: TooltipProps) {
           <div>
             <dt>불참</dt>
             <dd>{formatNumber(datum.absentCount)}</dd>
+          </div>
+          <div>
+            <dt>확인 불가</dt>
+            <dd>{formatNumber(datum.unresolvedCount)}</dd>
           </div>
         </dl>
       ) : (
@@ -184,27 +190,40 @@ export function VisualizationOverview({
     (item) => item.eligibleVoteCount > 0
   );
   const latestActiveWeek = activeWeeks.at(-1) ?? null;
-  const peakAbsentWeek = activeWeeks.reduce<typeof latestActiveWeek>(
+  const resolvedWeeks = activeWeeks.filter(
+    (item) => item.eligibleVoteCount - item.unresolvedCount > 0
+  );
+  const latestResolvedWeek = resolvedWeeks.at(-1) ?? null;
+  const peakAbsentWeek = resolvedWeeks.reduce<typeof latestResolvedWeek>(
     (currentPeak, week) => {
       if (!currentPeak) {
         return week;
       }
 
-      const peakRate = currentPeak.absentCount / currentPeak.eligibleVoteCount;
-      const nextRate = week.absentCount / week.eligibleVoteCount;
+      const peakRate =
+        currentPeak.absentCount /
+        (currentPeak.eligibleVoteCount - currentPeak.unresolvedCount);
+      const nextRate =
+        week.absentCount / (week.eligibleVoteCount - week.unresolvedCount);
       return nextRate > peakRate ? week : currentPeak;
     },
     null
   );
-  const latestParticipationRate = latestActiveWeek
-    ? (latestActiveWeek.eligibleVoteCount - latestActiveWeek.absentCount) /
-      latestActiveWeek.eligibleVoteCount
+  const latestParticipationRate = latestResolvedWeek
+    ? (latestResolvedWeek.eligibleVoteCount -
+        latestResolvedWeek.absentCount -
+        latestResolvedWeek.unresolvedCount) /
+      (latestResolvedWeek.eligibleVoteCount -
+        latestResolvedWeek.unresolvedCount)
     : null;
-  const latestAbsenceRate = latestActiveWeek
-    ? latestActiveWeek.absentCount / latestActiveWeek.eligibleVoteCount
+  const latestAbsenceRate = latestResolvedWeek
+    ? latestResolvedWeek.absentCount /
+      (latestResolvedWeek.eligibleVoteCount -
+        latestResolvedWeek.unresolvedCount)
     : null;
   const peakAbsenceRate = peakAbsentWeek
-    ? peakAbsentWeek.absentCount / peakAbsentWeek.eligibleVoteCount
+    ? peakAbsentWeek.absentCount /
+      (peakAbsentWeek.eligibleVoteCount - peakAbsentWeek.unresolvedCount)
     : null;
 
   const activePartyLineWeeks = partyLineTrendData.filter(
@@ -264,16 +283,16 @@ export function VisualizationOverview({
 
       <dl className="v3-metric-strip" aria-label="현재 추세 요약">
         <div>
-          <dt>최근 참여율</dt>
+          <dt>최근 확인된 참여율</dt>
           <dd>
             {latestParticipationRate !== null
               ? formatPercent(latestParticipationRate)
               : "—"}
           </dd>
           <small>
-            {latestActiveWeek
-              ? `${latestActiveWeek.weekStart} 시작 주`
-              : "표결 대기"}
+            {latestResolvedWeek
+              ? `${latestResolvedWeek.weekStart} 시작 주 · 확인된 표결 기준`
+              : "확인된 표결 대기"}
           </small>
         </div>
         <div className="v3-metric-strip__alert">
@@ -284,9 +303,9 @@ export function VisualizationOverview({
               : "—"}
           </dd>
           <small>
-            {latestActiveWeek
-              ? `${formatNumber(latestActiveWeek.absentCount)}건`
-              : "표결 대기"}
+            {latestResolvedWeek
+              ? `${formatNumber(latestResolvedWeek.absentCount)}건 명시 불참`
+              : "확인된 표결 대기"}
           </small>
         </div>
         <div>
@@ -314,7 +333,10 @@ export function VisualizationOverview({
           <header className="v3-evidence-panel__header">
             <div>
               <h3>주간 참여 구성</h3>
-              <p>찬성·반대·기권·불참이 전체 공개 기록에서 차지한 비중입니다.</p>
+              <p>
+                찬성·반대·기권·불참·확인 불가가 전체 공개 기록에서 차지한
+                비중입니다.
+              </p>
             </div>
             <span>{trendWindowPhrase}</span>
           </header>
@@ -326,7 +348,7 @@ export function VisualizationOverview({
                   <div
                     className="v3-chart"
                     role="img"
-                    aria-label={`${trendWindowPhrase} 찬성, 반대, 기권, 불참 비중 누적 영역 차트`}
+                    aria-label={`${trendWindowPhrase} 찬성, 반대, 기권, 불참, 확인 불가 비중 누적 영역 차트`}
                   >
                     <ResponsiveContainer width="100%" height={300}>
                       <AreaChart
@@ -399,6 +421,17 @@ export function VisualizationOverview({
                           connectNulls={false}
                           name="불참"
                         />
+                        <Area
+                          type="monotone"
+                          dataKey="unresolvedShare"
+                          stackId="vote-share"
+                          stroke={chartPalette.unresolved}
+                          fill={chartPalette.unresolved}
+                          fillOpacity={0.82}
+                          strokeWidth={1.5}
+                          connectNulls={false}
+                          name="확인 불가"
+                        />
                       </AreaChart>
                     </ResponsiveContainer>
                   </div>
@@ -418,6 +451,10 @@ export function VisualizationOverview({
                     <span>
                       <i style={{ backgroundColor: chartPalette.absent }} />
                       불참
+                    </span>
+                    <span>
+                      <i style={{ backgroundColor: chartPalette.unresolved }} />
+                      확인 불가
                     </span>
                   </div>
                 </div>
@@ -440,16 +477,21 @@ export function VisualizationOverview({
                     </small>
                   </div>
                   <div>
-                    <span>최근 참여 건수</span>
+                    <span>최근 확인된 참여 건수</span>
                     <strong>
                       {latestActiveWeek
                         ? formatNumber(
                             latestActiveWeek.eligibleVoteCount -
-                              latestActiveWeek.absentCount
+                              latestActiveWeek.absentCount -
+                              latestActiveWeek.unresolvedCount
                           )
                         : "—"}
                     </strong>
-                    <small>전체 eligible 기록 기준</small>
+                    <small>
+                      {latestActiveWeek
+                        ? `전체 eligible 기록 기준 · 확인 불가 ${formatNumber(latestActiveWeek.unresolvedCount)}건`
+                        : "전체 eligible 기록 기준"}
+                    </small>
                   </div>
                   <p>
                     빈 주간은 선으로 연결하지 않아 미관측을 0%로 오해하지 않게
@@ -469,6 +511,7 @@ export function VisualizationOverview({
                         <th scope="col">반대</th>
                         <th scope="col">기권</th>
                         <th scope="col">불참</th>
+                        <th scope="col">확인 불가</th>
                         <th scope="col">분모</th>
                       </tr>
                     </thead>
@@ -480,6 +523,7 @@ export function VisualizationOverview({
                           <td>{formatNumber(week.noCount)}</td>
                           <td>{formatNumber(week.abstainCount)}</td>
                           <td>{formatNumber(week.absentCount)}</td>
+                          <td>{formatNumber(week.unresolvedCount)}</td>
                           <td>
                             {week.eligibleVoteCount > 0
                               ? formatNumber(week.eligibleVoteCount)

--- a/apps/web/src/components/VoteMinutesOpinionPanel.tsx
+++ b/apps/web/src/components/VoteMinutesOpinionPanel.tsx
@@ -81,9 +81,7 @@ export function VoteMinutesOpinionPanel({
             <QuotesIcon size={17} weight="fill" aria-hidden="true" />
             공식 회의록 대조
           </p>
-          <h4 id={`vote-opinion-title-${vote.rollCallId}`}>
-            선택별 확인 발언
-          </h4>
+          <h4 id={`vote-opinion-title-${vote.rollCallId}`}>선택별 확인 발언</h4>
         </div>
         {opinion ? (
           <p className="vote-opinion-panel__coverage">

--- a/apps/web/src/components/WatchQueueSnapshot.tsx
+++ b/apps/web/src/components/WatchQueueSnapshot.tsx
@@ -29,6 +29,7 @@ type VoteWindowBreakdown = {
   noCount: number;
   abstainCount: number;
   absentCount: number;
+  unresolvedCount: number;
 };
 
 type QueueRecord = {
@@ -93,21 +94,27 @@ function buildVoteWindowBreakdown(args: {
   noCount: number;
   abstainCount: number;
   absentCount: number;
+  unresolvedCount: number;
 }): VoteWindowBreakdown {
   return {
     eligibleCount: args.eligibleCount,
     yesCount: Math.max(
       0,
-      args.eligibleCount - args.noCount - args.abstainCount - args.absentCount
+      args.eligibleCount -
+        args.noCount -
+        args.abstainCount -
+        args.absentCount -
+        args.unresolvedCount
     ),
     noCount: args.noCount,
     abstainCount: args.abstainCount,
-    absentCount: args.absentCount
+    absentCount: args.absentCount,
+    unresolvedCount: args.unresolvedCount
   };
 }
 
 function getDominantVoteRecord(window: VoteWindowBreakdown): {
-  key: "yes" | "no" | "abstain" | "absent";
+  key: "yes" | "no" | "abstain" | "absent" | "unknown";
   label: string;
   count: number;
 } {
@@ -115,7 +122,12 @@ function getDominantVoteRecord(window: VoteWindowBreakdown): {
     { key: "yes" as const, label: "찬성", count: window.yesCount },
     { key: "no" as const, label: "반대", count: window.noCount },
     { key: "abstain" as const, label: "기권", count: window.abstainCount },
-    { key: "absent" as const, label: "불참", count: window.absentCount }
+    { key: "absent" as const, label: "불참", count: window.absentCount },
+    {
+      key: "unknown" as const,
+      label: "확인 불가",
+      count: window.unresolvedCount
+    }
   ].reduce((dominant, item) => (item.count > dominant.count ? item : dominant));
 }
 
@@ -170,6 +182,13 @@ function buildChangeRecords(
 
   return (trends?.movers ?? [])
     .flatMap((mover): QueueRecord[] => {
+      if (
+        (mover.previousWindowUnresolvedCount ?? 0) > 0 ||
+        (mover.currentWindowUnresolvedCount ?? 0) > 0
+      ) {
+        return [];
+      }
+
       const previousValue = getWindowNegativeRate({
         noCount: mover.previousWindowNoCount,
         abstainCount: mover.previousWindowAbstainCount,
@@ -197,13 +216,15 @@ function buildChangeRecords(
         eligibleCount: mover.previousWindowEligibleCount,
         noCount: mover.previousWindowNoCount,
         abstainCount: mover.previousWindowAbstainCount,
-        absentCount: mover.previousWindowAbsentCount
+        absentCount: mover.previousWindowAbsentCount,
+        unresolvedCount: mover.previousWindowUnresolvedCount ?? 0
       });
       const currentBreakdown = buildVoteWindowBreakdown({
         eligibleCount: mover.currentWindowEligibleCount,
         noCount: mover.currentWindowNoCount,
         abstainCount: mover.currentWindowAbstainCount,
-        absentCount: mover.currentWindowAbsentCount
+        absentCount: mover.currentWindowAbsentCount,
+        unresolvedCount: mover.currentWindowUnresolvedCount ?? 0
       });
       return [
         {
@@ -317,13 +338,13 @@ function buildAbsenceRecords(
         district: member.district ?? null,
         photoUrl: member.photoUrl,
         recordType: "행위 부재" as const,
-        headline: `공개 기록표결 결석률이 ${formatPercent(absenceRate)}입니다.`,
+        headline: `공개 기록표결 불참률이 ${formatPercent(absenceRate)}입니다.`,
         rationale:
           "공개된 기록표결 중 불참으로 기록된 건수를 같은 분모로 비교했습니다.",
         previousValue: null,
         currentValue: absenceRate,
         delta: null,
-        currentLabel: "결석률",
+        currentLabel: "표결 불참률",
         actionLabel: "표결별 결석 근거 보기",
         basisLabel: `${formatNumber(
           member.totalRecordedVotes
@@ -377,6 +398,12 @@ function VoteComparison({
       label: "표결 불참",
       previous: comparison.previous.absentCount,
       current: comparison.current.absentCount,
+      summary: true
+    },
+    {
+      label: "확인 불가",
+      previous: comparison.previous.unresolvedCount,
+      current: comparison.current.unresolvedCount,
       summary: true
     }
   ];
@@ -478,11 +505,11 @@ export function WatchQueueSnapshot({
     >
       <header className="watch-queue-snapshot__heading">
         <div>
-          <h2 id="watch-queue-snapshot-title">국회 출석부</h2>
+          <h2 id="watch-queue-snapshot-title">공개 기록표결 현황</h2>
         </div>
         <p>
-          최근 수집된 공개 기록을 변화·결과·행위 부재 기준으로 확인하고 공식
-          근거까지 따라갑니다.
+          회의 출석률이 아닌 최근 공개 기록표결을 변화·결과·명시 불참·확인
+          불가로 나눠 확인하고 공식 근거까지 따라갑니다.
           {latestGeneratedAt ? (
             <time dateTime={latestGeneratedAt}>
               {` 최근 수집 ${formatDateTime(latestGeneratedAt)}`}
@@ -492,7 +519,10 @@ export function WatchQueueSnapshot({
       </header>
 
       <div className="watch-queue-workbench">
-        <aside className="watch-queue-filters" aria-label="국회 출석부 필터">
+        <aside
+          className="watch-queue-filters"
+          aria-label="공개 기록표결 현황 필터"
+        >
           <div>
             <h3>증거 상태</h3>
             {filterLabels.map((filter) => (
@@ -644,7 +674,10 @@ export function WatchQueueSnapshot({
           ) : null}
         </div>
 
-        <aside className="watch-queue-briefing" aria-label="국회 출석부 브리핑">
+        <aside
+          className="watch-queue-briefing"
+          aria-label="공개 기록표결 현황 브리핑"
+        >
           <section>
             <h3>공개 범위</h3>
             <dl>

--- a/apps/web/src/lib/accountability.ts
+++ b/apps/web/src/lib/accountability.ts
@@ -8,14 +8,78 @@ export type LeaderboardMetric =
   | "absent"
   | "partyLine";
 
+export function getUnresolvedCount(item: AccountabilitySummaryItem): number {
+  return item.unresolvedCount ?? 0;
+}
+
 export function getYesCount(item: AccountabilitySummaryItem): number {
   return Math.max(
     0,
     item.totalRecordedVotes -
       item.noCount -
       item.abstainCount -
-      item.absentCount
+      item.absentCount -
+      getUnresolvedCount(item)
   );
+}
+
+export function getParticipationCount(item: AccountabilitySummaryItem): number {
+  return Math.max(
+    0,
+    item.totalRecordedVotes - item.absentCount - getUnresolvedCount(item)
+  );
+}
+
+export function getParticipationRate(
+  item: AccountabilitySummaryItem
+): number | null {
+  const resolvedCount = Math.max(
+    0,
+    item.totalRecordedVotes - getUnresolvedCount(item)
+  );
+  return resolvedCount > 0 ? getParticipationCount(item) / resolvedCount : null;
+}
+
+export function buildParticipationSnapshot(
+  eligibleCount: number,
+  absentCount: number,
+  unresolvedCount: number
+): {
+  eligibleCount: number;
+  resolvedCount: number;
+  participatedCount: number;
+  absentCount: number;
+  unresolvedCount: number;
+  coverageRate: number | null;
+  rate: number | null;
+} {
+  const normalizedEligibleCount = Math.max(0, eligibleCount);
+  const normalizedUnresolvedCount = Math.min(
+    normalizedEligibleCount,
+    Math.max(0, unresolvedCount)
+  );
+  const resolvedCount = Math.max(
+    0,
+    normalizedEligibleCount - normalizedUnresolvedCount
+  );
+  const normalizedAbsentCount = Math.min(
+    resolvedCount,
+    Math.max(0, absentCount)
+  );
+  const participatedCount = Math.max(0, resolvedCount - normalizedAbsentCount);
+
+  return {
+    eligibleCount: normalizedEligibleCount,
+    resolvedCount,
+    participatedCount,
+    absentCount: normalizedAbsentCount,
+    unresolvedCount: normalizedUnresolvedCount,
+    coverageRate:
+      normalizedEligibleCount > 0
+        ? resolvedCount / normalizedEligibleCount
+        : null,
+    rate: resolvedCount > 0 ? participatedCount / resolvedCount : null
+  };
 }
 
 export function getYesRate(item: AccountabilitySummaryItem): number {

--- a/apps/web/src/lib/charts.ts
+++ b/apps/web/src/lib/charts.ts
@@ -8,10 +8,12 @@ export type WeeklyTrendChartDatum = {
   noShare: number | null;
   abstainShare: number | null;
   absentShare: number | null;
+  unresolvedShare: number | null;
   yesCount: number;
   noCount: number;
   abstainCount: number;
   absentCount: number;
+  unresolvedCount: number;
   eligibleVoteCount: number;
   negativeRate: number;
 };
@@ -60,8 +62,7 @@ export function buildWeeklyTrendChartData(
   }
 
   return trends.weeks.map((week) => {
-    const total =
-      week.yesCount + week.noCount + week.abstainCount + week.absentCount;
+    const total = week.eligibleVoteCount;
 
     return {
       weekStart: week.weekStart,
@@ -71,10 +72,13 @@ export function buildWeeklyTrendChartData(
       noShare: total > 0 ? (week.noCount / total) * 100 : null,
       abstainShare: total > 0 ? (week.abstainCount / total) * 100 : null,
       absentShare: total > 0 ? (week.absentCount / total) * 100 : null,
+      unresolvedShare:
+        total > 0 ? ((week.unresolvedCount ?? 0) / total) * 100 : null,
       yesCount: week.yesCount,
       noCount: week.noCount,
       abstainCount: week.abstainCount,
       absentCount: week.absentCount,
+      unresolvedCount: week.unresolvedCount ?? 0,
       eligibleVoteCount: week.eligibleVoteCount,
       negativeRate:
         week.eligibleVoteCount > 0

--- a/apps/web/src/lib/distribution.ts
+++ b/apps/web/src/lib/distribution.ts
@@ -1,5 +1,5 @@
-import { getYesCount } from "./accountability.js";
-import { getMemberAttendanceSummary } from "./member-activity.js";
+import { buildParticipationSnapshot, getYesCount } from "./accountability.js";
+import { getMemberDayBreakdown } from "./member-activity.js";
 
 import type {
   AccountabilitySummaryExport,
@@ -32,8 +32,12 @@ export type DistributionMemberPoint = {
   negativeRate: number;
   disruptionRate: number;
   attendanceRate: number;
-  eligibleDays: number;
-  attendedDays: number;
+  participationRateAvailable: boolean;
+  participationCoverageRate: number | null;
+  eligibleRollCallCount: number;
+  resolvedRollCallCount: number;
+  participatedRollCallCount: number;
+  unresolvedRollCallCount: number;
   yesDays: number;
   noDays: number;
   abstainDays: number;
@@ -66,6 +70,7 @@ export type DistributionBehaviorSummary = {
 export type DistributionPartySummary = {
   party: string;
   memberCount: number;
+  comparableMemberCount: number;
   averageAttendanceRate: number;
   averageSupportRate: number;
   averageNegativeRate: number;
@@ -227,10 +232,22 @@ export function buildDistributionMembers(
         return [];
       }
 
-      const attendanceSummary = getMemberAttendanceSummary(activityMember);
+      const dayBreakdown = getMemberDayBreakdown(activityMember);
+      const participation = buildParticipationSnapshot(
+        item.totalRecordedVotes,
+        item.absentCount,
+        item.unresolvedCount ?? 0
+      );
       const yesCount = getYesCount(item);
-      const negativeRate = item.noRate + item.abstainRate;
-      const disruptionRate = negativeRate + item.absentRate;
+      const resolvedCount = participation.resolvedCount;
+      const yesRate = resolvedCount > 0 ? yesCount / resolvedCount : 0;
+      const noRate = resolvedCount > 0 ? item.noCount / resolvedCount : 0;
+      const abstainRate =
+        resolvedCount > 0 ? item.abstainCount / resolvedCount : 0;
+      const absentRate =
+        resolvedCount > 0 ? item.absentCount / resolvedCount : 0;
+      const negativeRate = noRate + abstainRate;
+      const disruptionRate = negativeRate + absentRate;
 
       return [
         {
@@ -250,21 +267,22 @@ export function buildDistributionMembers(
           partyLineParticipationCount: item.partyLineParticipationCount,
           partyLineDefectionCount: item.partyLineDefectionCount,
           partyLineDefectionRate: item.partyLineDefectionRate,
-          yesRate:
-            item.totalRecordedVotes > 0
-              ? yesCount / item.totalRecordedVotes
-              : 0,
-          noRate: item.noRate,
-          abstainRate: item.abstainRate,
-          absentRate: item.absentRate,
+          yesRate,
+          noRate,
+          abstainRate,
+          absentRate,
           negativeRate,
           disruptionRate,
-          attendanceRate: attendanceSummary.attendanceRate,
-          eligibleDays: attendanceSummary.eligibleDays,
-          attendedDays: attendanceSummary.attendedDays,
-          yesDays: attendanceSummary.yesDays,
-          noDays: attendanceSummary.noDays,
-          abstainDays: attendanceSummary.abstainDays,
+          attendanceRate: participation.rate ?? 0,
+          participationRateAvailable: participation.rate !== null,
+          participationCoverageRate: participation.coverageRate,
+          eligibleRollCallCount: participation.eligibleCount,
+          resolvedRollCallCount: participation.resolvedCount,
+          participatedRollCallCount: participation.participatedCount,
+          unresolvedRollCallCount: participation.unresolvedCount,
+          yesDays: dayBreakdown.yesDays,
+          noDays: dayBreakdown.noDays,
+          abstainDays: dayBreakdown.abstainDays,
           absentDayCount: activityMember.absentDays,
           negativeDayCount: activityMember.negativeDays,
           currentNegativeStreak: activityMember.currentNegativeStreak,
@@ -283,6 +301,12 @@ export function buildDistributionMembers(
     .sort((left, right) => {
       if (right.disruptionRate !== left.disruptionRate) {
         return right.disruptionRate - left.disruptionRate;
+      }
+
+      if (
+        right.participationRateAvailable !== left.participationRateAvailable
+      ) {
+        return right.participationRateAvailable ? 1 : -1;
       }
 
       if (left.attendanceRate !== right.attendanceRate) {
@@ -326,19 +350,24 @@ export function buildDistributionPartySummaries(
 
   return [...groups.entries()]
     .map(([party, partyMembers]) => {
-      const totalAttendanceRate = partyMembers.reduce(
+      const comparableMembers = partyMembers.filter(
+        (member) => member.participationRateAvailable
+      );
+      const comparableMemberCount = comparableMembers.length;
+      const divisor = Math.max(comparableMemberCount, 1);
+      const totalAttendanceRate = comparableMembers.reduce(
         (sum, member) => sum + member.attendanceRate,
         0
       );
-      const totalSupportRate = partyMembers.reduce(
+      const totalSupportRate = comparableMembers.reduce(
         (sum, member) => sum + member.yesRate,
         0
       );
-      const totalNegativeRate = partyMembers.reduce(
+      const totalNegativeRate = comparableMembers.reduce(
         (sum, member) => sum + member.negativeRate,
         0
       );
-      const totalAbsenceRate = partyMembers.reduce(
+      const totalAbsenceRate = comparableMembers.reduce(
         (sum, member) => sum + member.absentRate,
         0
       );
@@ -351,10 +380,11 @@ export function buildDistributionPartySummaries(
       return {
         party,
         memberCount: partyMembers.length,
-        averageAttendanceRate: totalAttendanceRate / partyMembers.length,
-        averageSupportRate: totalSupportRate / partyMembers.length,
-        averageNegativeRate: totalNegativeRate / partyMembers.length,
-        averageAbsenceRate: totalAbsenceRate / partyMembers.length,
+        comparableMemberCount,
+        averageAttendanceRate: totalAttendanceRate / divisor,
+        averageSupportRate: totalSupportRate / divisor,
+        averageNegativeRate: totalNegativeRate / divisor,
+        averageAbsenceRate: totalAbsenceRate / divisor,
         topCurrentStreak
       };
     })

--- a/apps/web/src/lib/hex-cells.ts
+++ b/apps/web/src/lib/hex-cells.ts
@@ -16,6 +16,7 @@ export type SummaryItem = {
   absentRate: number;
   noRate: number;
   abstainRate: number;
+  voteMetricsAvailable?: boolean;
   realEstateTotal?: number | null;
   assetTotal?: number | null;
 };
@@ -109,6 +110,13 @@ export function endPerformanceSpan(span: PerformanceSpan): number {
 }
 
 function getMetricValue(item: SummaryItem, metric: MapMetric): number | null {
+  if (
+    (metric === "absence" || metric === "negative") &&
+    item.voteMetricsAvailable === false
+  ) {
+    return null;
+  }
+
   if (metric === "absence") {
     return item.absentRate;
   }

--- a/apps/web/src/lib/member-activity.ts
+++ b/apps/web/src/lib/member-activity.ts
@@ -43,6 +43,7 @@ export type MemberDayBreakdown = {
   noDays: number;
   abstainDays: number;
   absentDays: number;
+  unknownDays: number;
 };
 
 export type MemberAttendanceSummary = MemberDayBreakdown & {
@@ -99,7 +100,10 @@ export function getMemberDayBreakdown(
     noDays: member.dayStates.filter((day) => day.state === "no").length,
     abstainDays: member.dayStates.filter((day) => day.state === "abstain")
       .length,
-    absentDays: member.dayStates.filter((day) => day.state === "absent").length
+    absentDays: member.dayStates.filter((day) => day.state === "absent").length,
+    unknownDays: member.dayStates.filter(
+      (day) => day.state === "unknown" || day.unknownCount > 0
+    ).length
   };
 }
 
@@ -108,7 +112,10 @@ export function getMemberAttendanceSummary(
 ): MemberAttendanceSummary {
   const breakdown = getMemberDayBreakdown(member);
   const eligibleDays = member.dayStates.length;
-  const attendedDays = Math.max(0, eligibleDays - breakdown.absentDays);
+  const attendedDays = Math.max(
+    0,
+    eligibleDays - breakdown.absentDays - breakdown.unknownDays
+  );
 
   return {
     ...breakdown,

--- a/apps/web/src/v2/V2NationalMap.tsx
+++ b/apps/web/src/v2/V2NationalMap.tsx
@@ -294,7 +294,7 @@ export function V2NationalMap({
 }: V2NationalMapProps) {
   const metricLabel =
     metric === "absence"
-      ? "결석률"
+      ? "재임 누적 표결 불참률"
       : metric === "negative"
         ? "반대·기권률"
         : metric === "realEstate"
@@ -302,7 +302,7 @@ export function V2NationalMap({
           : "공개 총재산";
   const distributionLabel =
     metric === "absence"
-      ? "결석률"
+      ? "누적 표결 불참률"
       : metric === "negative"
         ? "표결 성향"
         : "재산";
@@ -340,15 +340,22 @@ export function V2NationalMap({
       }
 
       const assetSummary = assetByMemberId.get(item.memberId);
+      const resolvedVoteCount = Math.max(
+        0,
+        item.totalRecordedVotes - (item.unresolvedCount ?? 0)
+      );
       return [
         {
           memberId: item.memberId,
           name: item.name,
           party: item.party,
           district: item.district,
-          absentRate: item.absentRate,
-          noRate: item.noRate,
-          abstainRate: item.abstainRate,
+          absentRate:
+            resolvedVoteCount > 0 ? item.absentCount / resolvedVoteCount : 0,
+          noRate: resolvedVoteCount > 0 ? item.noCount / resolvedVoteCount : 0,
+          abstainRate:
+            resolvedVoteCount > 0 ? item.abstainCount / resolvedVoteCount : 0,
+          voteMetricsAvailable: resolvedVoteCount > 0,
           assetTotal: assetSummary?.assetTotal ?? null,
           realEstateTotal: assetSummary?.realEstateTotal ?? null
         }

--- a/apps/web/src/v2/V2ObservatoryPage.tsx
+++ b/apps/web/src/v2/V2ObservatoryPage.tsx
@@ -81,7 +81,16 @@ type TrendPoint = {
   primary: number | null;
   secondary: number | null;
   tertiary: number | null;
+  quaternary?: number | null;
+  quinary?: number | null;
 };
+
+type TrendValueKey =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "quaternary"
+  | "quinary";
 
 type RankingRow = {
   memberId: string;
@@ -106,6 +115,7 @@ type LensConfig = {
   trendKicker: string;
   trendTitle: string;
   trendSeries: [string, string, string];
+  trendAdditionalSeries?: readonly string[];
   trendCategoryLabel: string;
   rankingTitle: string;
   scoreLabel: string;
@@ -116,21 +126,26 @@ type LensConfig = {
 const LENS_CONFIGS: LensConfig[] = [
   {
     key: "attendance",
-    label: "출석",
+    label: "표결 참여",
     icon: UsersThreeIcon,
     mapMetric: "absence",
-    mapTitle: "지역별 결석률 분포",
+    mapTitle: "지역별 재임 누적 표결 불참률 분포",
     scatterTitle: "정당별 의원 분포",
-    xLabel: "출석률",
+    xLabel: "확인된 재임 누적 표결 참여율",
     yLabel: "반대·기권 비중",
     trendKicker: "시간 흐름",
-    trendTitle: "최근 12주 출석률 추이",
-    trendSeries: ["최고", "전체 평균", "최저"],
+    trendTitle: "최근 12주 공개 기록표결 확인된 참여율 추이",
+    trendSeries: [
+      "최고 확인된 참여율",
+      "평균 확인된 참여율",
+      "최저 확인된 참여율"
+    ],
+    trendAdditionalSeries: ["확인 불가 비중"],
     trendCategoryLabel: "기간",
-    rankingTitle: "의원 출석률 상위 5 / 하위 5",
-    scoreLabel: "평균 출석률",
+    rankingTitle: "의원 확인된 표결 참여율 상위 5 / 하위 5",
+    scoreLabel: "확인된 표결 참여율",
     supportLabel: "반대·기권 비중",
-    basisLabel: "출석 실적 기준"
+    basisLabel: "재임 중 참여 대상 공개 기록표결 기준"
   },
   {
     key: "voting",
@@ -143,7 +158,8 @@ const LENS_CONFIGS: LensConfig[] = [
     yLabel: "당내 이탈률",
     trendKicker: "시간 흐름",
     trendTitle: "최근 12주 표결 구성 추이",
-    trendSeries: ["찬성", "반대", "불참"],
+    trendSeries: ["찬성", "반대", "기권"],
+    trendAdditionalSeries: ["불참", "확인 불가"],
     trendCategoryLabel: "기간",
     rankingTitle: "찬성 비중 상위 5 / 하위 5",
     scoreLabel: "찬성 비중",
@@ -201,18 +217,24 @@ function buildAttendanceTrend(
 
   const memberWeeks = new Map<
     string,
-    Map<string, { attended: number; total: number }>
+    Map<string, { attended: number; unresolved: number; total: number }>
   >();
 
   for (const member of calendar.assembly.members) {
-    const weeks = new Map<string, { attended: number; total: number }>();
+    const weeks = new Map<
+      string,
+      { attended: number; unresolved: number; total: number }
+    >();
     for (const day of member.dayStates) {
       const weekKey = getWeekKey(day.date);
-      const current = weeks.get(weekKey) ?? { attended: 0, total: 0 };
-      current.total += 1;
-      if (day.state !== "absent") {
-        current.attended += 1;
-      }
+      const current = weeks.get(weekKey) ?? {
+        attended: 0,
+        unresolved: 0,
+        total: 0
+      };
+      current.total += day.totalRollCalls;
+      current.attended += day.yesCount + day.noCount + day.abstainCount;
+      current.unresolved += day.unknownCount;
       weeks.set(weekKey, current);
     }
     memberWeeks.set(member.memberId, weeks);
@@ -227,23 +249,43 @@ function buildAttendanceTrend(
   return weekKeys.map((weekKey) => {
     const rates = [...memberWeeks.values()].flatMap((weeks) => {
       const week = weeks.get(weekKey);
-      return week && week.total > 0 ? [(week.attended / week.total) * 100] : [];
+      if (!week || week.total <= 0) {
+        return [];
+      }
+      const resolved = Math.max(0, week.total - week.unresolved);
+      return [
+        {
+          confirmedParticipation:
+            resolved > 0 ? (week.attended / resolved) * 100 : null,
+          unresolved: (week.unresolved / week.total) * 100
+        }
+      ];
     });
+    const confirmedRates = rates.flatMap((rate) =>
+      rate.confirmedParticipation === null ? [] : [rate.confirmedParticipation]
+    );
 
     if (rates.length === 0) {
       return {
         label: formatShortDate(weekKey),
         primary: null,
         secondary: null,
-        tertiary: null
+        tertiary: null,
+        quaternary: null
       };
     }
 
     return {
       label: formatShortDate(weekKey),
-      primary: Math.max(...rates),
-      secondary: rates.reduce((sum, value) => sum + value, 0) / rates.length,
-      tertiary: Math.min(...rates)
+      primary: confirmedRates.length > 0 ? Math.max(...confirmedRates) : null,
+      secondary:
+        confirmedRates.length > 0
+          ? confirmedRates.reduce((sum, rate) => sum + rate, 0) /
+            confirmedRates.length
+          : null,
+      tertiary: confirmedRates.length > 0 ? Math.min(...confirmedRates) : null,
+      quaternary:
+        rates.reduce((sum, rate) => sum + rate.unresolved, 0) / rates.length
     };
   });
 }
@@ -257,7 +299,9 @@ function buildVotingTrend(
       label: point.label,
       primary: point.yesShare,
       secondary: point.noShare,
-      tertiary: point.absentShare
+      tertiary: point.abstainShare,
+      quaternary: point.absentShare,
+      quinary: point.unresolvedShare
     }));
 }
 
@@ -288,6 +332,9 @@ function buildPoints(
   return members.flatMap((member): ObservatoryPoint[] => {
     const district = member.district ?? "비례대표";
     if (lens === "attendance") {
+      if (!member.participationRateAvailable) {
+        return [];
+      }
       return [
         {
           memberId: member.memberId,
@@ -300,7 +347,7 @@ function buildPoints(
           score: member.attendanceRate * 100,
           supportValue: member.negativeRate * 100,
           pointWeight: 1,
-          basisValue: `${member.attendedDays}일`
+          basisValue: `${member.participatedRollCallCount}/${member.resolvedRollCallCount}건 확인`
         }
       ];
     }
@@ -608,6 +655,51 @@ export function V2ObservatoryPage({
   const excludedVotingPointCount =
     activeLens === "voting" ? members.length - points.length : 0;
   const latestTrendPoint = trendData[trendData.length - 1] ?? null;
+  const trendLineSeries: Array<{
+    dataKey: TrendValueKey;
+    label: string;
+    color: string;
+  }> = [
+    {
+      dataKey: "secondary",
+      label: config.trendSeries[1],
+      color: "#575148"
+    },
+    {
+      dataKey: "primary",
+      label: config.trendSeries[0],
+      color: "#95622d"
+    },
+    {
+      dataKey: "tertiary",
+      label: config.trendSeries[2],
+      color: "#5b6c00"
+    },
+    ...(config.trendAdditionalSeries ?? []).slice(0, 2).map(
+      (
+        label,
+        index
+      ): {
+        dataKey: TrendValueKey;
+        label: string;
+        color: string;
+      } => ({
+        dataKey: index === 0 ? "quaternary" : "quinary",
+        label,
+        color: index === 0 ? "#7d7468" : "#a85e3d"
+      })
+    )
+  ];
+  const trendTableSeries = [...trendLineSeries].sort((left, right) => {
+    const order: TrendValueKey[] = [
+      "primary",
+      "secondary",
+      "tertiary",
+      "quaternary",
+      "quinary"
+    ];
+    return order.indexOf(left.dataKey) - order.indexOf(right.dataKey);
+  });
 
   function selectLens(lens: ObservatoryLens, focus = false) {
     setActiveLens(lens);
@@ -645,10 +737,10 @@ export function V2ObservatoryPage({
       <header className="v2-observatory__hero">
         <div>
           <p className="v2-observatory__eyebrow">
-            국회 출석부 · {assemblyLabel} 공식 기록
+            국회 출석부 · {assemblyLabel} 공개 기록표결
           </p>
           <h1 className="v2-observatory__title" tabIndex={-1}>
-            실시간 국회 출석부
+            실시간 국회 공개 기록표결
           </h1>
           <p className="v2-observatory__intro">
             최근 발언·의안·표결의 변화와 행위 부재를 근거 단위로 비교하고
@@ -992,18 +1084,16 @@ export function V2ObservatoryPage({
                 activeLens === "assets" ? "재산 비교 범례" : "추세 범례"
               }
             >
-              <span>
-                <i className="v2-dot v2-dot--green" aria-hidden="true" />
-                {config.trendSeries[1]}
-              </span>
-              <span>
-                <i className="v2-dot v2-dot--blue" aria-hidden="true" />
-                {config.trendSeries[0]}
-              </span>
-              <span>
-                <i className="v2-dot v2-dot--red" aria-hidden="true" />
-                {config.trendSeries[2]}
-              </span>
+              {trendLineSeries.map((series) => (
+                <span key={series.dataKey}>
+                  <i
+                    className="v2-dot"
+                    style={{ backgroundColor: series.color }}
+                    aria-hidden="true"
+                  />
+                  {series.label}
+                </span>
+              ))}
             </div>
             {activeLens === "assets" ? (
               <p className="v2-trend-scale-note">
@@ -1021,6 +1111,11 @@ export function V2ObservatoryPage({
                       <th scope="col">{config.trendSeries[0]}</th>
                       <th scope="col">{config.trendSeries[1]}</th>
                       <th scope="col">{config.trendSeries[2]}</th>
+                      {(config.trendAdditionalSeries ?? []).map((label) => (
+                        <th key={label} scope="col">
+                          {label}
+                        </th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody>
@@ -1037,17 +1132,15 @@ export function V2ObservatoryPage({
                             point.label
                           )}
                         </th>
-                        {[point.primary, point.secondary, point.tertiary].map(
-                          (value, index) => (
-                            <td key={`${point.label}-${index}`}>
-                              {value == null
-                                ? "—"
-                                : activeLens === "assets"
-                                  ? formatEok(value)
-                                  : formatPercentValue(value)}
-                            </td>
-                          )
-                        )}
+                        {trendTableSeries.map((series) => (
+                          <td key={`${point.label}-${series.dataKey}`}>
+                            {point[series.dataKey] == null
+                              ? "—"
+                              : activeLens === "assets"
+                                ? formatEok(point[series.dataKey]!)
+                                : formatPercentValue(point[series.dataKey]!)}
+                          </td>
+                        ))}
                       </tr>
                     ))}
                   </tbody>
@@ -1148,33 +1241,18 @@ export function V2ObservatoryPage({
                         return formatPercentValue(Number(rawValue ?? 0));
                       }}
                     />
-                    <Line
-                      type="monotone"
-                      dataKey="secondary"
-                      name={config.trendSeries[1]}
-                      stroke="#575148"
-                      strokeWidth={2}
-                      dot={{ r: 2.5 }}
-                      connectNulls
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="primary"
-                      name={config.trendSeries[0]}
-                      stroke="#95622d"
-                      strokeWidth={2}
-                      dot={{ r: 2.5 }}
-                      connectNulls
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="tertiary"
-                      name={config.trendSeries[2]}
-                      stroke="#5b6c00"
-                      strokeWidth={2}
-                      dot={{ r: 2.5 }}
-                      connectNulls
-                    />
+                    {trendLineSeries.map((series) => (
+                      <Line
+                        key={series.dataKey}
+                        type="monotone"
+                        dataKey={series.dataKey}
+                        name={series.label}
+                        stroke={series.color}
+                        strokeWidth={2}
+                        dot={{ r: 2.5 }}
+                        connectNulls
+                      />
+                    ))}
                   </LineChart>
                 )}
                 {latestTrendPoint && activeLens !== "assets" ? (

--- a/apps/web/src/v2/V2RouteContent.tsx
+++ b/apps/web/src/v2/V2RouteContent.tsx
@@ -211,7 +211,7 @@ export function V2RouteContent() {
 
   if (routeState.route === "trends") {
     return (
-      <Suspense fallback={<RouteLoadingFallback title="출석 추이" />}>
+      <Suspense fallback={<RouteLoadingFallback title="표결 참여 추이" />}>
         <TrendsPage
           accountabilityTrends={accountabilityTrends}
           accountabilitySummary={accountabilitySummary}

--- a/packages/ingest/src/exports.ts
+++ b/packages/ingest/src/exports.ts
@@ -62,9 +62,12 @@ type ExportBuildOptions = {
 type PublicVoteCode = Exclude<VoteCode, "absent">;
 type MemberCentricVoteCode = Extract<
   VoteCode,
-  "yes" | "no" | "abstain" | "absent"
+  "yes" | "no" | "abstain" | "absent" | "unknown"
 >;
-type PartyLineMajorityVoteCode = Exclude<MemberCentricVoteCode, "absent">;
+type PartyLineMajorityVoteCode = Exclude<
+  MemberCentricVoteCode,
+  "absent" | "unknown"
+>;
 type VoteHighlight = {
   memberId: string | null;
   memberName: string;
@@ -104,7 +107,8 @@ type CommitteeSummary = {
   eligibleRollCallCount: number;
   participatedRollCallCount: number;
   absentRollCallCount: number;
-  participationRate: number;
+  unresolvedRollCallCount: number;
+  participationRate: number | null;
   yesCount: number;
   noCount: number;
   abstainCount: number;
@@ -123,6 +127,7 @@ type WindowVoteCounts = {
   noCount: number;
   abstainCount: number;
   absentCount: number;
+  unresolvedCount: number;
   partyLineOpportunityCount: number;
   partyLineParticipationCount: number;
   partyLineDefectionCount: number;
@@ -144,7 +149,6 @@ type RollCallVoteResolution = {
   explicitCounts: LatestVoteCounts;
   absentListStatus?: AbsentListStatus;
   explicitAbsentMemberIds: Set<string>;
-  verifiedDerivedAbsentMemberIds: Set<string>;
   missingEligibleMemberIds: Set<string>;
 };
 
@@ -310,6 +314,7 @@ function createWindowVoteCounts(): WindowVoteCounts {
     noCount: 0,
     abstainCount: 0,
     absentCount: 0,
+    unresolvedCount: 0,
     partyLineOpportunityCount: 0,
     partyLineParticipationCount: 0,
     partyLineDefectionCount: 0
@@ -377,20 +382,14 @@ function resolveRollCallVoteCounts(args: {
     ? Math.max(officialTally.registeredCount - officialTally.presentCount, 0)
     : null;
   let absentListStatus: AbsentListStatus | undefined;
-  let verifiedDerivedAbsentMemberIds = new Set<string>();
-
   if (canDeriveAbsences) {
     if (officialTally) {
-      const expectedDerivedAbsentCount = Math.max(
-        (officialAbsentCount ?? 0) - explicitAbsentMemberIds.size,
-        0
-      );
       const presentMatches = rowPresentCount === officialTally.presentCount;
-      const missingMatches =
-        missingEligibleMemberIds.size === expectedDerivedAbsentCount;
-      if (presentMatches && missingMatches) {
+      const explicitAbsencesMatch =
+        explicitAbsentMemberIds.size === officialAbsentCount;
+      const rosterIsComplete = missingEligibleMemberIds.size === 0;
+      if (presentMatches && explicitAbsencesMatch && rosterIsComplete) {
         absentListStatus = "verified";
-        verifiedDerivedAbsentMemberIds = new Set(missingEligibleMemberIds);
       } else {
         absentListStatus = "unavailable";
       }
@@ -419,14 +418,13 @@ function resolveRollCallVoteCounts(args: {
     explicitCounts,
     absentListStatus,
     explicitAbsentMemberIds,
-    verifiedDerivedAbsentMemberIds,
     missingEligibleMemberIds
   };
 }
 
 function accumulateVoteCounts(
   target: WindowVoteCounts,
-  voteCode?: VoteCode
+  voteCode: MemberCentricVoteCode
 ): void {
   target.eligibleCount += 1;
 
@@ -440,8 +438,13 @@ function accumulateVoteCounts(
     return;
   }
 
-  if (!voteCode || voteCode === "absent") {
+  if (voteCode === "absent") {
     target.absentCount += 1;
+    return;
+  }
+
+  if (voteCode === "unknown") {
+    target.unresolvedCount += 1;
   }
 }
 
@@ -454,7 +457,8 @@ function resolveCalendarState(bucket: DayBucket): CalendarState {
     { state: "absent", count: bucket.absentCount, priority: 4 },
     { state: "no", count: bucket.noCount, priority: 3 },
     { state: "abstain", count: bucket.abstainCount, priority: 2 },
-    { state: "yes", count: bucket.yesCount, priority: 1 }
+    { state: "yes", count: bucket.yesCount, priority: 1 },
+    { state: "unknown", count: bucket.unknownCount, priority: 0 }
   ];
   const bestMatch = rankedStates.reduce<{
     state: CalendarState;
@@ -687,12 +691,13 @@ function resolveMemberCentricVoteCode(args: {
   if (
     explicitVoteCode === "yes" ||
     explicitVoteCode === "no" ||
-    explicitVoteCode === "abstain"
+    explicitVoteCode === "abstain" ||
+    explicitVoteCode === "absent"
   ) {
     return explicitVoteCode;
   }
 
-  return "absent";
+  return "unknown";
 }
 
 function resolvePartyLineMajorityVoteCode(args: {
@@ -758,7 +763,7 @@ function buildPartyLineMajoritiesByRollCall(args: {
         memberId: member.memberId,
         voteCodeLookup: args.voteCodeLookup
       });
-      if (voteCode === "absent") {
+      if (voteCode === "absent" || voteCode === "unknown") {
         continue;
       }
 
@@ -810,7 +815,7 @@ function accumulatePartyLineCounts(args: {
 }): void {
   args.target.partyLineOpportunityCount += 1;
 
-  if (args.voteCode === "absent") {
+  if (args.voteCode === "absent" || args.voteCode === "unknown") {
     return;
   }
 
@@ -904,6 +909,7 @@ function buildCommitteeSummariesByMember(args: {
         eligibleRollCallCount: 0,
         participatedRollCallCount: 0,
         absentRollCallCount: 0,
+        unresolvedRollCallCount: 0,
         yesCount: 0,
         noCount: 0,
         abstainCount: 0
@@ -924,8 +930,10 @@ function buildCommitteeSummariesByMember(args: {
       } else if (voteCode === "abstain") {
         currentSummary.participatedRollCallCount += 1;
         currentSummary.abstainCount += 1;
-      } else {
+      } else if (voteCode === "absent") {
         currentSummary.absentRollCallCount += 1;
+      } else {
+        currentSummary.unresolvedRollCallCount += 1;
       }
 
       summaryByCommittee.set(committeeName, currentSummary);
@@ -941,21 +949,27 @@ function buildCommitteeSummariesByMember(args: {
     const voteRecords =
       args.memberVoteRecordsByMember.get(member.memberId) ?? [];
     const summaries = [...summaryByCommittee.values()]
-      .map((summary) => ({
-        ...summary,
-        participationRate:
-          summary.eligibleRollCallCount === 0
-            ? 0
-            : summary.participatedRollCallCount / summary.eligibleRollCallCount,
-        isCurrentCommittee: currentCommittees.has(summary.committeeName),
-        recentVoteRecords: voteRecords
-          .filter(
-            (record) =>
-              normalizeCommitteeName(record.committeeName) ===
-              summary.committeeName
-          )
-          .slice(0, 3)
-      }))
+      .map((summary) => {
+        const resolvedRollCallCount = Math.max(
+          0,
+          summary.eligibleRollCallCount - summary.unresolvedRollCallCount
+        );
+        return {
+          ...summary,
+          participationRate:
+            resolvedRollCallCount === 0
+              ? null
+              : summary.participatedRollCallCount / resolvedRollCallCount,
+          isCurrentCommittee: currentCommittees.has(summary.committeeName),
+          recentVoteRecords: voteRecords
+            .filter(
+              (record) =>
+                normalizeCommitteeName(record.committeeName) ===
+                summary.committeeName
+            )
+            .slice(0, 3)
+        };
+      })
       .filter((summary) => summary.eligibleRollCallCount > 0)
       .sort((left, right) => {
         if (right.eligibleRollCallCount !== left.eligibleRollCallCount) {
@@ -974,20 +988,27 @@ function buildCommitteeSummariesByMember(args: {
 function buildHomeCommitteeAlerts(
   summaries: CommitteeSummary[]
 ): HomeCommitteeAlert[] {
-  return summaries
-    .filter(
-      (summary) =>
-        summary.isCurrentCommittee &&
-        summary.eligibleRollCallCount >= 5 &&
-        summary.participationRate < 0.5
-    )
-    .map((summary) => ({
-      committeeName: summary.committeeName,
-      participationRate: summary.participationRate,
-      eligibleRollCallCount: summary.eligibleRollCallCount,
-      participatedRollCallCount: summary.participatedRollCallCount,
-      message: "현재 소속 위원회 표결 참여율이 낮습니다."
-    }));
+  return summaries.flatMap((summary) => {
+    if (
+      !summary.isCurrentCommittee ||
+      summary.eligibleRollCallCount < 5 ||
+      summary.unresolvedRollCallCount > 0 ||
+      summary.participationRate === null ||
+      summary.participationRate >= 0.5
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        committeeName: summary.committeeName,
+        participationRate: summary.participationRate,
+        eligibleRollCallCount: summary.eligibleRollCallCount,
+        participatedRollCallCount: summary.participatedRollCallCount,
+        message: "현재 소속 위원회가 소관한 본회의 기록표결 참여율이 낮습니다."
+      }
+    ];
+  });
 }
 
 function toPublicMemberProfile(
@@ -1142,20 +1163,8 @@ export function buildLatestVotesExport(
       const recordedAbsentVotes: VoteHighlight[] = votes
         .filter((vote) => vote.voteCode === "absent")
         .map((vote) => buildLeanLatestVoteMember({ vote, membersById }));
-      const derivedAbsentVotes: VoteHighlight[] = eligibleCurrentMembers
-        .filter((member) =>
-          resolution.verifiedDerivedAbsentMemberIds.has(member.memberId)
-        )
-        .map((member) => ({
-          memberId: member.memberId,
-          memberName: member.name,
-          party: member.party,
-          ...buildLeanLatestVoteMemberMetadata(),
-          voteCode: "absent" as const
-        }));
-      const absentVotes = [...recordedAbsentVotes, ...derivedAbsentVotes].sort(
-        (left, right) =>
-          left.memberName.localeCompare(right.memberName, "ko-KR")
+      const absentVotes = recordedAbsentVotes.sort((left, right) =>
+        left.memberName.localeCompare(right.memberName, "ko-KR")
       );
       const explicitMemberVotes =
         rollCallIndex < latestPlenaryMemberVoteLimit
@@ -1171,9 +1180,8 @@ export function buildLatestVotesExport(
           : [];
       const memberVotes =
         rollCallIndex < latestPlenaryMemberVoteLimit
-          ? [...explicitMemberVotes, ...derivedAbsentVotes].sort(
-              (left, right) =>
-                left.memberName.localeCompare(right.memberName, "ko-KR")
+          ? explicitMemberVotes.sort((left, right) =>
+              left.memberName.localeCompare(right.memberName, "ko-KR")
             )
           : [];
       const memberVoteListStatus =
@@ -1300,6 +1308,7 @@ export function buildAccountabilitySummaryExport(
       let noCount = 0;
       let abstainCount = 0;
       let absentCount = 0;
+      let unresolvedCount = 0;
       let partyLineOpportunityCount = 0;
       let partyLineParticipationCount = 0;
       let partyLineDefectionCount = 0;
@@ -1317,6 +1326,8 @@ export function buildAccountabilitySummaryExport(
           abstainCount += 1;
         } else if (voteCode === "absent") {
           absentCount += 1;
+        } else if (voteCode === "unknown") {
+          unresolvedCount += 1;
         }
 
         const party = resolveMemberPartyForRollCall({
@@ -1329,7 +1340,7 @@ export function buildAccountabilitySummaryExport(
           : undefined;
         if (partyMajority) {
           partyLineOpportunityCount += 1;
-          if (voteCode !== "absent") {
+          if (voteCode !== "absent" && voteCode !== "unknown") {
             partyLineParticipationCount += 1;
             if (voteCode !== partyMajority.voteCode) {
               partyLineDefectionCount += 1;
@@ -1351,6 +1362,7 @@ export function buildAccountabilitySummaryExport(
         noCount,
         abstainCount,
         absentCount,
+        unresolvedCount,
         noRate: noCount / denominator,
         abstainRate: abstainCount / denominator,
         absentRate: absentCount / denominator,
@@ -1680,6 +1692,7 @@ export function buildAccountabilityTrendsExport(
         noCount: 0,
         abstainCount: 0,
         absentCount: 0,
+        unresolvedCount: 0,
         eligibleVoteCount: 0,
         partyLineOpportunityCount: 0,
         partyLineParticipationCount: 0,
@@ -1767,6 +1780,8 @@ export function buildAccountabilityTrendsExport(
           weeklyTrend.abstainCount += 1;
         } else if (voteCode === "absent") {
           weeklyTrend.absentCount += 1;
+        } else if (voteCode === "unknown") {
+          weeklyTrend.unresolvedCount += 1;
         }
         if (partyMajority) {
           accumulatePartyLineCounts({
@@ -1819,6 +1834,7 @@ export function buildAccountabilityTrendsExport(
           noCount: 0,
           abstainCount: 0,
           absentCount: 0,
+          unresolvedCount: 0,
           eligibleVoteCount: 0,
           partyLineOpportunityCount: 0,
           partyLineParticipationCount: 0,
@@ -1841,6 +1857,7 @@ export function buildAccountabilityTrendsExport(
           previousWindowNoCount: mover?.previous.noCount ?? 0,
           previousWindowAbstainCount: mover?.previous.abstainCount ?? 0,
           previousWindowAbsentCount: mover?.previous.absentCount ?? 0,
+          previousWindowUnresolvedCount: mover?.previous.unresolvedCount ?? 0,
           previousWindowPartyLineOpportunityCount:
             mover?.previous.partyLineOpportunityCount ?? 0,
           previousWindowPartyLineParticipationCount:
@@ -1851,6 +1868,7 @@ export function buildAccountabilityTrendsExport(
           currentWindowNoCount: mover?.current.noCount ?? 0,
           currentWindowAbstainCount: mover?.current.abstainCount ?? 0,
           currentWindowAbsentCount: mover?.current.absentCount ?? 0,
+          currentWindowUnresolvedCount: mover?.current.unresolvedCount ?? 0,
           currentWindowPartyLineOpportunityCount:
             mover?.current.partyLineOpportunityCount ?? 0,
           currentWindowPartyLineParticipationCount:
@@ -1988,11 +2006,14 @@ export function buildMemberActivityCalendarArtifacts(
       );
       const sequence = [...eligibleDates]
         .sort(compareDateKeys)
-        .map((date) => stateByDate.get(date) ?? "absent");
+        .map((date) => stateByDate.get(date) ?? "unknown");
       const negativeDays = sequence.filter(
         (state) => state === "no" || state === "abstain"
       ).length;
       const absentDays = sequence.filter((state) => state === "absent").length;
+      const unknownDays = normalizedDayStates.filter(
+        (dayState) => dayState.unknownCount > 0
+      ).length;
       const committeeSummaries =
         committeeSummariesByMember.get(member.memberId) ?? [];
       memberDetails.push({
@@ -2016,6 +2037,7 @@ export function buildMemberActivityCalendarArtifacts(
         longestNegativeOrAbsentStreak: calculateLongestStreak(sequence, true),
         negativeDays,
         absentDays,
+        unknownDays,
         committeeSummaries,
         homeCommitteeAlerts: buildHomeCommitteeAlerts(committeeSummaries),
         dayStates: normalizedDayStates,

--- a/packages/ingest/src/minutes-summarization.ts
+++ b/packages/ingest/src/minutes-summarization.ts
@@ -725,9 +725,7 @@ function parseSelectedCandidateIndices(
     throw new Error("The local model did not return sentence indices.");
   }
 
-  const parsed = JSON.parse(serialized) as
-    | { indices?: unknown }
-    | unknown[];
+  const parsed = JSON.parse(serialized) as { indices?: unknown } | unknown[];
   const rawIndices = Array.isArray(parsed) ? parsed : parsed.indices;
   if (!Array.isArray(rawIndices)) {
     throw new Error("The local model returned an invalid index payload.");

--- a/packages/ingest/src/vote-minutes-opinions.ts
+++ b/packages/ingest/src/vote-minutes-opinions.ts
@@ -44,9 +44,7 @@ function resolveMemberVoteCode(args: {
     return highlightedVote.voteCode;
   }
 
-  if (
-    args.item.absentVotes.some((vote) => vote.memberId === args.memberId)
-  ) {
+  if (args.item.absentVotes.some((vote) => vote.memberId === args.memberId)) {
     return "absent";
   }
 
@@ -103,11 +101,7 @@ export function buildVoteMinutesOpinionsExport(args: {
           memberId: summary.memberId,
           voteRecordsByMemberId: args.voteRecordsByMemberId
         });
-        if (
-          voteCode !== "yes" &&
-          voteCode !== "no" &&
-          voteCode !== "abstain"
-        ) {
+        if (voteCode !== "yes" && voteCode !== "no" && voteCode !== "abstain") {
           return [];
         }
 
@@ -147,9 +141,8 @@ export function buildVoteMinutesOpinionsExport(args: {
         billName: item.billName,
         majorityVoteCode: resolveMajorityVoteCode(item.counts),
         matchMethod: "bill_id" as const,
-        sourceMeetingCount: new Set(
-          evidence.map((entry) => entry.documentId)
-        ).size,
+        sourceMeetingCount: new Set(evidence.map((entry) => entry.documentId))
+          .size,
         sourceStatementCount: evidence.length,
         latestMeetingDate: evidence[0]?.meetingDate ?? item.voteDatetime,
         evidence

--- a/packages/schemas/src/contracts.ts
+++ b/packages/schemas/src/contracts.ts
@@ -258,6 +258,7 @@ export const accountabilitySummaryItemSchema = z.object({
   noCount: z.number().int().nonnegative(),
   abstainCount: z.number().int().nonnegative(),
   absentCount: z.number().int().nonnegative().default(0),
+  unresolvedCount: z.number().int().nonnegative().default(0),
   noRate: z.number().min(0).max(1),
   abstainRate: z.number().min(0).max(1),
   absentRate: z.number().min(0).max(1).default(0),
@@ -385,6 +386,7 @@ export const weeklyAssemblyTrendPointSchema = z.object({
   noCount: z.number().int().nonnegative(),
   abstainCount: z.number().int().nonnegative(),
   absentCount: z.number().int().nonnegative(),
+  unresolvedCount: z.number().int().nonnegative().default(0),
   eligibleVoteCount: z.number().int().nonnegative(),
   partyLineOpportunityCount: z.number().int().nonnegative().default(0),
   partyLineParticipationCount: z.number().int().nonnegative().default(0),
@@ -402,6 +404,7 @@ export const accountabilityMoverWindowSchema = z.object({
   previousWindowNoCount: z.number().int().nonnegative(),
   previousWindowAbstainCount: z.number().int().nonnegative(),
   previousWindowAbsentCount: z.number().int().nonnegative(),
+  previousWindowUnresolvedCount: z.number().int().nonnegative().default(0),
   previousWindowPartyLineOpportunityCount: z
     .number()
     .int()
@@ -421,6 +424,7 @@ export const accountabilityMoverWindowSchema = z.object({
   currentWindowNoCount: z.number().int().nonnegative(),
   currentWindowAbstainCount: z.number().int().nonnegative(),
   currentWindowAbsentCount: z.number().int().nonnegative(),
+  currentWindowUnresolvedCount: z.number().int().nonnegative().default(0),
   currentWindowPartyLineOpportunityCount: z
     .number()
     .int()
@@ -457,7 +461,7 @@ export const memberActivityDayStateSchema = z.object({
   totalRollCalls: z.number().int().nonnegative().default(0),
   state: z
     .enum(["yes", "no", "abstain", "absent", "unknown", "missing"])
-    .transform((state) => (state === "missing" ? "absent" : state))
+    .transform((state) => (state === "missing" ? "unknown" : state))
 });
 
 export const memberActivityVoteRecordSchema = z.object({
@@ -465,7 +469,7 @@ export const memberActivityVoteRecordSchema = z.object({
   billName: nonEmptyString,
   committeeName: nonEmptyString.nullable().optional(),
   voteDatetime: nonEmptyString,
-  voteCode: z.enum(["yes", "no", "abstain", "absent"]),
+  voteCode: z.enum(["yes", "no", "abstain", "absent", "unknown"]),
   officialSourceUrl: nonEmptyString.url().nullable().optional()
 });
 
@@ -474,7 +478,8 @@ export const memberActivityCommitteeSummarySchema = z.object({
   eligibleRollCallCount: z.number().int().nonnegative(),
   participatedRollCallCount: z.number().int().nonnegative(),
   absentRollCallCount: z.number().int().nonnegative(),
-  participationRate: z.number().min(0).max(1),
+  unresolvedRollCallCount: z.number().int().nonnegative().default(0),
+  participationRate: z.number().min(0).max(1).nullable(),
   yesCount: z.number().int().nonnegative(),
   noCount: z.number().int().nonnegative(),
   abstainCount: z.number().int().nonnegative(),
@@ -505,6 +510,7 @@ const memberActivityCalendarMemberBaseSchema = z
     longestNegativeOrAbsentStreak: z.number().int().nonnegative(),
     negativeDays: z.number().int().nonnegative(),
     absentDays: z.number().int().nonnegative(),
+    unknownDays: z.number().int().nonnegative().default(0),
     committeeMemberships: z.array(nonEmptyString).default([]),
     committeeSummaries: z
       .array(memberActivityCommitteeSummarySchema)
@@ -548,7 +554,8 @@ export const memberActivityCalendarMemberSchema = z.preprocess((input) => {
     longestNegativeOrAbsentStreak:
       record.longestNegativeOrAbsentStreak ??
       record.longestNegativeOrMissingStreak,
-    absentDays: record.absentDays ?? record.missingDays,
+    absentDays: record.absentDays ?? 0,
+    unknownDays: record.unknownDays ?? record.missingDays ?? 0,
     voteRecordCount: record.voteRecordCount ?? voteRecords.length,
     voteRecordsPath:
       record.voteRecordsPath ??

--- a/scripts/generate-member-share-pages.mjs
+++ b/scripts/generate-member-share-pages.mjs
@@ -24,7 +24,7 @@ const DEFAULT_CARD_FONT_FILES = [
   )
 );
 const CARD_GENERATION_CONCURRENCY = 2;
-const CARD_RENDERER_VERSION = "member-share-card-v6-vote-participation-rate";
+const CARD_RENDERER_VERSION = "member-share-card-v7-unresolved-vote-coverage";
 const MEMBER_CARD_PALETTE = Object.freeze({
   paper: "#e7e7e1",
   paperDeep: "#c9cac4",
@@ -90,16 +90,23 @@ function formatRatePercent(value) {
 }
 
 function getVoteParticipation(accountability) {
-  const totalCount = accountability.totalRecordedVotes;
+  const totalCount = Math.max(0, accountability.totalRecordedVotes);
+  const unresolvedCount = Math.min(
+    totalCount,
+    Math.max(0, accountability.unresolvedCount ?? 0)
+  );
+  const resolvedCount = Math.max(0, totalCount - unresolvedCount);
   const participatedCount = Math.max(
     0,
-    totalCount - accountability.absentCount
+    resolvedCount - accountability.absentCount
   );
 
   return {
     totalCount,
+    resolvedCount,
+    unresolvedCount,
     participatedCount,
-    rate: totalCount > 0 ? participatedCount / totalCount : null
+    rate: resolvedCount > 0 ? participatedCount / resolvedCount : null
   };
 }
 
@@ -547,10 +554,20 @@ function buildEvidenceFacts(member) {
     const participation = getVoteParticipation(member.accountability);
     facts.push(
       participation.rate === null
-        ? "공개 기록표결 자료 없음"
-        : `기록표결 ${formatInteger(
-            participation.totalCount
-          )}건 중 ${formatInteger(participation.participatedCount)}건 참여`
+        ? participation.totalCount > 0
+          ? `기록표결 ${formatInteger(
+              participation.totalCount
+            )}건 · 의원별 표결행 ${formatInteger(
+              participation.unresolvedCount
+            )}건 확인 불가`
+          : "공개 기록표결 자료 없음"
+        : `확인된 기록표결 ${formatInteger(
+            participation.resolvedCount
+          )}건 중 ${formatInteger(participation.participatedCount)}건 참여${
+            participation.unresolvedCount > 0
+              ? ` · 확인 불가 ${formatInteger(participation.unresolvedCount)}건`
+              : ""
+          }`
     );
   } else if (member.activity?.voteRecordCount !== undefined) {
     facts.push(
@@ -597,18 +614,26 @@ function buildPerformanceHighlights(member) {
   if (member.accountability) {
     const participation = getVoteParticipation(member.accountability);
     highlights.push({
-      label: "표결 참여율",
+      label: "확인된 표결 참여율",
       value:
         participation.rate === null
-          ? "자료 없음"
+          ? "산정 불가"
           : formatRatePercent(participation.rate),
-      contextLabel: "기록표결",
+      contextLabel: "의원별 표결행",
       contextValue:
         participation.rate === null
-          ? "자료 없음"
+          ? participation.totalCount > 0
+            ? `확인 불가 ${formatInteger(
+                participation.unresolvedCount
+              )} / ${formatInteger(participation.totalCount)}건`
+            : "자료 없음"
           : `${formatInteger(participation.participatedCount)} / ${formatInteger(
-              participation.totalCount
-            )}건`
+              participation.resolvedCount
+            )}건${
+              participation.unresolvedCount > 0
+                ? ` · 미확인 ${formatInteger(participation.unresolvedCount)}건`
+                : ""
+            }`
     });
   } else if (member.activity?.voteRecordCount !== undefined) {
     highlights.push({

--- a/tests/ingest/member-share-pages.test.ts
+++ b/tests/ingest/member-share-pages.test.ts
@@ -309,9 +309,9 @@ describe("generateMemberSharePages", () => {
       }
     );
     const svg = renderMemberCardSvg(memberModel);
-    expect(svg).toContain("기록표결 40건 중 35건 참여");
+    expect(svg).toContain("확인된 기록표결 40건 중 35건 참여");
     expect(svg).toContain("대표발의 12건 · 처리결과 확인 7건");
-    expect(svg).toContain(">표결 참여율</text>");
+    expect(svg).toContain(">확인된 표결 참여율</text>");
     expect(svg).toContain(">87.5%</text>");
     expect(svg).toContain(">35 / 40건</text>");
     expect(svg).not.toContain(">불참</text>");
@@ -328,9 +328,44 @@ describe("generateMemberSharePages", () => {
     expect(cardsManifest).toMatchObject({
       snapshotId: "snapshot-123",
       cardVersion: expect.stringMatching(/^[a-f0-9]{16}$/),
-      cardRendererVersion: "member-share-card-v6-vote-participation-rate",
+      cardRendererVersion: "member-share-card-v7-unresolved-vote-coverage",
       count: 1
     });
+  });
+
+  it("does not turn unresolved member vote rows into participation metadata", () => {
+    const memberModel = buildMemberCardModel(
+      {
+        memberId: "MRS4949T",
+        name: "이소희",
+        party: "국민의힘",
+        district: "비례대표",
+        photoUrl: "https://images.example.test/MRS4949T.jpg",
+        accountability: {
+          totalRecordedVotes: 537,
+          absentCount: 0,
+          unresolvedCount: 537,
+          partyLineDefectionCount: 0,
+          partyLineParticipationCount: 0
+        }
+      },
+      {
+        appBaseUrl: "https://app.example.test/lawmaker-monitor/",
+        assemblyLabel: "제22대 국회",
+        generatedAt: "2026-07-30T10:00:00.000Z",
+        snapshotId: "snapshot-123"
+      }
+    );
+    const svg = renderMemberCardSvg(memberModel);
+
+    expect(memberModel.description).toContain(
+      "기록표결 537건 · 의원별 표결행 537건 확인 불가"
+    );
+    expect(memberModel.description).not.toContain("537건 참여");
+    expect(svg).toContain(">확인된 표결 참여율</text>");
+    expect(svg).toContain(">산정 불가</text>");
+    expect(svg).toContain(">확인 불가 537 / 537건</text>");
+    expect(svg).not.toContain(">0.0%</text>");
   });
 
   it("fails generation when remote member data is unavailable", async () => {

--- a/tests/ingest/minutes-summarization.test.ts
+++ b/tests/ingest/minutes-summarization.test.ts
@@ -625,15 +625,13 @@ describe("minutes transcript summarization", () => {
           agendaTitle: "테스트 안건",
           billIds: [],
           speakerRole: "위원",
-          text:
-            "현황을 보고받았습니다. 제도 개선이 필요합니다. 예산도 검토해야 합니다. 다음 회의에서 다시 확인하겠습니다.",
+          text: "현황을 보고받았습니다. 제도 개선이 필요합니다. 예산도 검토해야 합니다. 다음 회의에서 다시 확인하겠습니다.",
           statementIds: ["statement-1"],
           sourceUrl:
             "https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?id=1&type=view",
           sourceFragment: "#statement-1"
         },
-        text:
-          "현황을 보고받았습니다. 제도 개선이 필요합니다. 예산도 검토해야 합니다. 다음 회의에서 다시 확인하겠습니다."
+        text: "현황을 보고받았습니다. 제도 개선이 필요합니다. 예산도 검토해야 합니다. 다음 회의에서 다시 확인하겠습니다."
       })
     ).resolves.toBe("제도 개선이 필요합니다.");
 

--- a/tests/ingest/pipeline.test.ts
+++ b/tests/ingest/pipeline.test.ts
@@ -725,6 +725,29 @@ describe("data pipeline contracts", () => {
       voteRecordsPath: "exports/member_activity_calendar_members/M002.json"
     });
     expect(
+      memberActivityCalendarMemberSchema.parse({
+        ...summaryMemberWithoutEmbeddedRecords,
+        absentDays: undefined,
+        missingDays: 2,
+        dayStates: [
+          {
+            date: "2026-03-20",
+            yesCount: 0,
+            noCount: 0,
+            abstainCount: 0,
+            absentCount: 0,
+            unknownCount: 1,
+            totalRollCalls: 1,
+            state: "missing"
+          }
+        ]
+      })
+    ).toMatchObject({
+      absentDays: 0,
+      unknownDays: 2,
+      dayStates: [expect.objectContaining({ state: "unknown" })]
+    });
+    expect(
       memberActivityCalendarMemberDetailExportSchema.parse(
         memberActivityCalendarMemberDetailFixture
       )
@@ -1282,6 +1305,7 @@ describe("data pipeline contracts", () => {
       )
     ).toMatchObject({
       absentDays: 0,
+      unknownDays: 0,
       negativeDays: 1
     });
   });
@@ -1375,7 +1399,8 @@ describe("data pipeline contracts", () => {
     expect(accountabilitySummary.items[0]).toMatchObject({
       totalRecordedVotes: 2,
       noCount: 1,
-      absentCount: 1
+      absentCount: 0,
+      unresolvedCount: 1
     });
     expect(
       memberActivityCalendar.assembly.members[0]?.committeeSummaries
@@ -1385,8 +1410,9 @@ describe("data pipeline contracts", () => {
           committeeName: "법제사법위원회",
           eligibleRollCallCount: 2,
           participatedRollCallCount: 1,
-          absentRollCallCount: 1,
-          participationRate: 0.5
+          absentRollCallCount: 0,
+          unresolvedRollCallCount: 1,
+          participationRate: 1
         })
       ])
     );
@@ -1394,11 +1420,13 @@ describe("data pipeline contracts", () => {
       expect.objectContaining({
         date: "2026-03-20",
         noCount: 1,
-        absentCount: 1,
+        absentCount: 0,
+        unknownCount: 1,
         totalRollCalls: 2,
-        state: "absent"
+        state: "no"
       })
     ]);
+    expect(memberActivityCalendar.assembly.members[0]?.unknownDays).toBe(1);
   });
 
   it("uses official roll-call totals but avoids deriving absent names when row totals do not match", () => {
@@ -1536,38 +1564,43 @@ describe("data pipeline contracts", () => {
       accountabilitySummary.items.find((item) => item.memberId === "M003")
     ).toMatchObject({
       totalRecordedVotes: 1,
-      absentCount: 1
+      absentCount: 0,
+      unresolvedCount: 1
     });
     expect(
       accountabilitySummary.items.find((item) => item.memberId === "M004")
     ).toMatchObject({
       totalRecordedVotes: 1,
-      absentCount: 1
+      absentCount: 0,
+      unresolvedCount: 1
     });
     expect(
       accountabilityTrends.movers.find((member) => member.memberId === "M003")
     ).toMatchObject({
       currentWindowEligibleCount: 1,
-      currentWindowAbsentCount: 1
+      currentWindowAbsentCount: 0,
+      currentWindowUnresolvedCount: 1
     });
     expect(
       accountabilityTrends.movers.find((member) => member.memberId === "M004")
     ).toMatchObject({
       currentWindowEligibleCount: 1,
-      currentWindowAbsentCount: 1
+      currentWindowAbsentCount: 0,
+      currentWindowUnresolvedCount: 1
     });
     expect(
       memberActivityCalendar.assembly.members.find(
         (member) => member.memberId === "M003"
       )
     ).toMatchObject({
-      absentDays: 1,
+      absentDays: 0,
+      unknownDays: 1,
       dayStates: [
         expect.objectContaining({
           date: "2026-03-24",
-          absentCount: 1,
-          unknownCount: 0,
-          state: "absent"
+          absentCount: 0,
+          unknownCount: 1,
+          state: "unknown"
         })
       ]
     });
@@ -1576,7 +1609,8 @@ describe("data pipeline contracts", () => {
         (member) => member.memberId === "M004"
       )
     ).toMatchObject({
-      absentDays: 1
+      absentDays: 0,
+      unknownDays: 1
     });
   });
 

--- a/tests/web/activity-calendar-page.test.tsx
+++ b/tests/web/activity-calendar-page.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ActivityCalendarPage } from "../../apps/web/src/components/ActivityCalendarPage.js";
@@ -107,5 +107,57 @@ describe("activity calendar profile avatars", () => {
         ".activity-compare__column .member-identity__avatar--activity-card"
       )
     ).toHaveLength(2);
+  });
+
+  it("does not rank a committee or show zero percent when its vote rows are unresolved", async () => {
+    const activityCalendarWithUnknown = {
+      ...activityCalendarFixture,
+      assembly: {
+        ...activityCalendarFixture.assembly,
+        members: activityCalendarFixture.assembly.members.map(
+          (member: { memberId: string }) =>
+            member.memberId === "M001"
+              ? {
+                  ...member,
+                  committeeSummaries: [
+                    {
+                      committeeName: "보건복지위원회",
+                      eligibleRollCallCount: 34,
+                      participatedRollCallCount: 0,
+                      absentRollCallCount: 0,
+                      unresolvedRollCallCount: 34,
+                      participationRate: 0,
+                      yesCount: 0,
+                      noCount: 0,
+                      abstainCount: 0,
+                      isCurrentCommittee: true,
+                      recentVoteRecords: []
+                    }
+                  ]
+                }
+              : member
+        )
+      }
+    };
+    const { getByRole } = renderActivityCalendarPage({
+      activityCalendar: activityCalendarWithUnknown,
+      initialMemberId: "M001"
+    });
+
+    const committeeRegion = await waitFor(() =>
+      getByRole("region", {
+        name: "위원회 소관 안건 본회의 확인된 표결 참여율"
+      })
+    );
+    expect(
+      within(committeeRegion).getByRole("heading", {
+        name: "표결행 확인 부족"
+      })
+    ).toBeInTheDocument();
+    expect(within(committeeRegion).getByText("산정 불가")).toBeInTheDocument();
+    expect(
+      within(committeeRegion).getByText(/확인 불가 34/)
+    ).toBeInTheDocument();
+    expect(within(committeeRegion).queryByText("0%")).toBeNull();
   });
 });

--- a/tests/web/distribution.test.tsx
+++ b/tests/web/distribution.test.tsx
@@ -37,7 +37,9 @@ describe("distribution helpers", () => {
       partyLineParticipationCount: 0,
       partyLineDefectionCount: 0,
       partyLineDefectionRate: 0,
-      attendanceRate: 2 / 3,
+      attendanceRate: 0.5,
+      eligibleRollCallCount: 2,
+      participatedRollCallCount: 1,
       currentNegativeOrAbsentStreak: 3
     });
     expect(members[1]).toMatchObject({
@@ -58,11 +60,75 @@ describe("distribution helpers", () => {
     expect(partySummaries).toHaveLength(1);
     expect(partySummaries[0]?.party).toBe("미래개혁당");
     expect(partySummaries[0]?.memberCount).toBe(2);
-    expect(partySummaries[0]?.averageAttendanceRate).toBeCloseTo(5 / 6);
+    expect(partySummaries[0]?.comparableMemberCount).toBe(2);
+    expect(partySummaries[0]?.averageAttendanceRate).toBeCloseTo(0.75);
     expect(partySummaries[0]?.averageSupportRate).toBeCloseTo(0.25);
     expect(partySummaries[0]?.averageNegativeRate).toBeCloseTo(0.5);
     expect(partySummaries[0]?.averageAbsenceRate).toBeCloseTo(0.25);
     expect(partySummaries[0]?.topCurrentStreak).toBe(3);
+  });
+
+  it("keeps fully unresolved members out of participation rates and party averages", () => {
+    const baseAccountability = accountabilitySummaryFixture.items.find(
+      (item: { memberId: string }) => item.memberId === "M001"
+    );
+    const baseActivity = memberActivityCalendarFixture.assembly.members.find(
+      (item: { memberId: string }) => item.memberId === "M001"
+    );
+    const accountabilityWithUnknown = {
+      ...accountabilitySummaryFixture,
+      items: [
+        ...accountabilitySummaryFixture.items,
+        {
+          ...baseAccountability,
+          memberId: "M004",
+          name: "확인불가",
+          totalRecordedVotes: 537,
+          noCount: 0,
+          abstainCount: 0,
+          absentCount: 0,
+          unresolvedCount: 537,
+          noRate: 0,
+          abstainRate: 0,
+          absentRate: 0
+        }
+      ]
+    };
+    const activityWithUnknown = {
+      ...memberActivityCalendarFixture,
+      assembly: {
+        ...memberActivityCalendarFixture.assembly,
+        members: [
+          ...memberActivityCalendarFixture.assembly.members,
+          {
+            ...baseActivity,
+            memberId: "M004",
+            name: "확인불가"
+          }
+        ]
+      }
+    };
+
+    const members = buildDistributionMembers(
+      accountabilityWithUnknown,
+      activityWithUnknown
+    );
+    const unknownMember = members.find((member) => member.memberId === "M004");
+    const partySummary = buildDistributionPartySummaries(members)[0];
+
+    expect(unknownMember).toMatchObject({
+      participationRateAvailable: false,
+      eligibleRollCallCount: 537,
+      resolvedRollCallCount: 0,
+      unresolvedRollCallCount: 537,
+      participatedRollCallCount: 0,
+      absentVoteCount: 0
+    });
+    expect(partySummary).toMatchObject({
+      memberCount: 3,
+      comparableMemberCount: 2
+    });
+    expect(partySummary?.averageAttendanceRate).toBeCloseTo(0.75);
   });
 
   it("builds behavior archetype summaries and matching cohorts", () => {

--- a/tests/web/entry-url.test.tsx
+++ b/tests/web/entry-url.test.tsx
@@ -24,8 +24,6 @@ describe("entry URL normalization", () => {
       buildEntryUrlWithoutUiParameter(
         "https://kuil09.github.io/lawmaker-monitor/?ui=v1&deploy=abc123#map?province=%EC%84%9C%EC%9A%B8"
       )
-    ).toBe(
-      "/lawmaker-monitor/?deploy=abc123#map?province=%EC%84%9C%EC%9A%B8"
-    );
+    ).toBe("/lawmaker-monitor/?deploy=abc123#map?province=%EC%84%9C%EC%9A%B8");
   });
 });

--- a/tests/web/evidence-pages.test.tsx
+++ b/tests/web/evidence-pages.test.tsx
@@ -188,6 +188,57 @@ describe("evidence exploration pages", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps unresolved voting windows out of the steady comparison state", () => {
+    const trendsWithUnresolvedWindow: AccountabilityTrendsExport = {
+      ...accountabilityTrendsFixture,
+      movers: accountabilityTrendsFixture.movers.map((mover) =>
+        mover.memberId === "M001"
+          ? {
+              ...mover,
+              previousWindowEligibleCount: 2,
+              previousWindowNoCount: 0,
+              previousWindowAbstainCount: 0,
+              previousWindowAbsentCount: 0,
+              previousWindowUnresolvedCount: 1,
+              currentWindowEligibleCount: 2,
+              currentWindowNoCount: 0,
+              currentWindowAbstainCount: 0,
+              currentWindowAbsentCount: 0,
+              currentWindowUnresolvedCount: 0
+            }
+          : mover
+      )
+    };
+
+    render(
+      <TrendsPage
+        accountabilityTrends={trendsWithUnresolvedWindow}
+        accountabilitySummary={accountabilitySummaryFixture}
+        billProposalActivity={billProposalActivityFixture}
+        assemblyLabel="제22대 국회"
+      />
+    );
+
+    const memberItem = screen
+      .getByRole("link", { name: /김아라/ })
+      .closest("li");
+    expect(memberItem?.getAttribute("data-docket-status")).toContain(
+      "unobserved"
+    );
+    expect(memberItem?.getAttribute("data-docket-status")).not.toContain(
+      "steady"
+    );
+    expect(
+      within(memberItem as HTMLElement).getByText("관측 대기")
+    ).toBeInTheDocument();
+    expect(
+      within(memberItem as HTMLElement).getByText("확인 불가")
+    ).toBeInTheDocument();
+    expect(
+      within(memberItem as HTMLElement).queryByText("0.0%")
+    ).not.toBeInTheDocument();
+  });
+
   it("reveals long vote histories in bounded pages", () => {
     const paginationItems = Array.from({ length: 25 }, (_, index) => ({
       ...latestVotesFixture.items[0],

--- a/tests/web/hex-cells.test.tsx
+++ b/tests/web/hex-cells.test.tsx
@@ -224,4 +224,37 @@ describe("hex-cells", () => {
       memberNames: ["김아라"]
     });
   });
+
+  it("keeps unresolved vote coverage neutral instead of mapping it as zero absence", () => {
+    const hydrated = hydrateHexCells(
+      [
+        {
+          h3Index: "8730c16f0ffffff",
+          districtKey: "부산남구",
+          districtLabel: "부산 남구",
+          provinceShortName: "부산"
+        }
+      ],
+      [
+        {
+          memberId: "M004",
+          name: "확인불가",
+          party: "미래개혁당",
+          district: "부산 남구",
+          absentRate: 0,
+          noRate: 0,
+          abstainRate: 0,
+          voteMetricsAvailable: false
+        }
+      ] satisfies SummaryItem[],
+      "absence"
+    );
+
+    expect(hydrated[0]).toMatchObject({
+      memberCount: 1,
+      metricMemberCount: 0,
+      metric: 0,
+      memberNames: ["확인불가"]
+    });
+  });
 });

--- a/tests/web/hexmap-page.test.tsx
+++ b/tests/web/hexmap-page.test.tsx
@@ -54,7 +54,7 @@ describe("HexmapPage", () => {
       "true"
     );
     expect(
-      screen.getByRole("tab", { name: "결석률 본회의 기준" })
+      screen.getByRole("tab", { name: "표결 불참률 본회의 기준" })
     ).toHaveAttribute("aria-selected", "true");
     expect(document.querySelector(".hexmap-page")).toHaveAttribute(
       "data-active-metric",
@@ -66,7 +66,7 @@ describe("HexmapPage", () => {
     ).toHaveTextContent("김아라");
     const proportionalComparison = screen
       .getByRole("heading", {
-        name: "결석률 · 비례대표 의원 비교"
+        name: "표결 불참률 · 비례대표 의원 비교"
       })
       .closest("section");
     expect(proportionalComparison).not.toBeNull();
@@ -162,16 +162,18 @@ describe("HexmapPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "시·도 요약" }));
 
     expect(
-      screen.getByRole("heading", { name: "시·도별 결석률 분포" })
+      screen.getByRole("heading", { name: "시·도별 표결 불참률 분포" })
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("시·도별 결석률 비교")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("시·도별 표결 불참률 비교")
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("complementary", { name: "선택한 지역의 요약" })
     ).toHaveTextContent("서울");
     expect(screen.getByText(/전국 상대 순위/)).toBeInTheDocument();
 
     const busanSummaryButton = screen
-      .getByLabelText("시·도별 결석률 비교")
+      .getByLabelText("시·도별 표결 불참률 비교")
       .querySelector<HTMLButtonElement>('button[data-province="부산"]');
     expect(busanSummaryButton).not.toBeNull();
     fireEvent.click(busanSummaryButton!);
@@ -211,5 +213,35 @@ describe("HexmapPage", () => {
     expect(
       screen.queryByRole("heading", { name: "지역별 국회 기록 탐색" })
     ).not.toBeInTheDocument();
+  });
+
+  it("shows unresolved vote coverage as missing data instead of zero absence", () => {
+    const unresolvedSummary = {
+      ...accountabilitySummaryFixture,
+      items: accountabilitySummaryFixture.items.map(
+        (item: { memberId: string }) =>
+          item.memberId === "M001"
+            ? {
+                ...item,
+                totalRecordedVotes: 537,
+                noCount: 0,
+                abstainCount: 0,
+                absentCount: 0,
+                unresolvedCount: 537,
+                noRate: 0,
+                abstainRate: 0,
+                absentRate: 0
+              }
+            : item
+      )
+    };
+
+    renderPage({ accountabilitySummary: unresolvedSummary });
+
+    const detail = screen.getByRole("complementary", {
+      name: "선택한 의원의 기록"
+    });
+    expect(within(detail).getAllByText("자료 없음").length).toBeGreaterThan(0);
+    expect(within(detail).queryByText("표결 불참률 0.0%")).toBeNull();
   });
 });

--- a/tests/web/member-evaluation-dossier.test.tsx
+++ b/tests/web/member-evaluation-dossier.test.tsx
@@ -84,8 +84,10 @@ describe("member evaluation dossier", () => {
       within(evidenceGrid!).getByText("2 / 2 (100.0%)")
     ).toBeInTheDocument();
     expect(
-      within(evidenceGrid!).getByText("분모: 의원별 참여 대상 공개 기록표결")
-    ).toBeInTheDocument();
+      within(evidenceGrid!).getAllByText(
+        "확인된 표결 2건 / 전체 대상 2건 · 확인 불가 0건"
+      ).length
+    ).toBeGreaterThanOrEqual(4);
     expect(
       getByText("반대 여부는 의안별 판단 기록이며 평가 점수가 아닙니다.")
     ).toBeInTheDocument();
@@ -98,6 +100,53 @@ describe("member evaluation dossier", () => {
 
     expect(getAllByText(/2025년 3월 27일/).length).toBeGreaterThan(0);
     expect(getAllByText(/2025년 4월 29일/).length).toBeGreaterThan(0);
+  });
+
+  it("shows participation as unavailable when every member vote row is unresolved", () => {
+    const unresolvedItem = {
+      ...accountabilityItem,
+      totalRecordedVotes: 537,
+      noCount: 0,
+      abstainCount: 0,
+      absentCount: 0,
+      unresolvedCount: 537,
+      noRate: 0,
+      abstainRate: 0,
+      absentRate: 0,
+      lastVoteAt: null
+    };
+    const { container } = render(
+      <MemberEvaluationDossier
+        assembly={activity.assembly}
+        member={member}
+        accountabilityItem={unresolvedItem}
+        voteRecords={[]}
+        voteRecordCount={537}
+        voteRecordsLoading={false}
+        voteRecordsError={null}
+        resolvedDistrict="비례대표"
+        onShare={vi.fn()}
+      />
+    );
+    const evidenceGrid = container.querySelector(
+      ".member-evaluation__evidence-grid"
+    );
+
+    expect(evidenceGrid).not.toBeNull();
+    expect(
+      within(evidenceGrid!).getAllByText("산정 불가").length
+    ).toBeGreaterThanOrEqual(4);
+    expect(
+      within(evidenceGrid!).getByText(
+        "537건 모두 의원별 표결행을 확인할 수 없습니다."
+      )
+    ).toBeInTheDocument();
+    expect(
+      within(evidenceGrid!).getByText(
+        "확인 불가 537건 · 불참으로 추론하지 않음"
+      )
+    ).toBeInTheDocument();
+    expect(within(evidenceGrid!).queryByText("0 / 537 (0.0%)")).toBeNull();
   });
 
   it("does not infer proportional representation when region data is missing", () => {

--- a/tests/web/member-photo.test.tsx
+++ b/tests/web/member-photo.test.tsx
@@ -78,8 +78,6 @@ describe("member photo optimization", () => {
       <MemberIdentity name="이서진" party="더불어민주당" district={null} />
     );
 
-    expect(
-      getByText("더불어민주당 · 지역 정보 미확인")
-    ).toBeInTheDocument();
+    expect(getByText("더불어민주당 · 지역 정보 미확인")).toBeInTheDocument();
   });
 });

--- a/tests/web/v2-observatory.test.tsx
+++ b/tests/web/v2-observatory.test.tsx
@@ -14,7 +14,7 @@ vi.mock("../../apps/web/src/v2/V2NationalMap.js", () => ({
   V2NationalMap: ({ metric }: { metric: string }) => {
     const metricLabel =
       metric === "absence"
-        ? "결석률"
+        ? "재임 누적 표결 불참률"
         : metric === "negative"
           ? "반대·기권률"
           : "공개 부동산액";
@@ -125,7 +125,7 @@ describe("v2 observatory", () => {
     );
 
     const watchQueueHeading = screen.getByRole("heading", {
-      name: "국회 출석부"
+      name: "공개 기록표결 현황"
     });
     const explorerHeading = screen.getByRole("heading", {
       name: "전국 지표 탐색"
@@ -142,8 +142,16 @@ describe("v2 observatory", () => {
     expect(
       screen.getByRole("tablist", { name: "전국 지표 탐색 선택" })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: "최근 12주 공개 기록표결 확인된 참여율 추이"
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("추세 범례")).getByText("확인 불가 비중")
+    ).toBeInTheDocument();
 
-    const attendanceTab = screen.getByRole("tab", { name: "출석" });
+    const attendanceTab = screen.getByRole("tab", { name: "표결 참여" });
     const observatoryPanel = screen.getByRole("tabpanel");
     expect(attendanceTab).toHaveAttribute(
       "aria-controls",
@@ -154,18 +162,20 @@ describe("v2 observatory", () => {
       "v2-lens-tab-attendance"
     );
     expect(
-      screen.getByRole("region", { name: "지역별 결석률 분포" })
+      screen.getByRole("region", {
+        name: "지역별 재임 누적 표결 불참률 분포"
+      })
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("region", { name: "지역별 출석률 분포" })
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("region", {
-        name: "전국 지역구 결석률 카토그램"
+        name: "전국 지역구 재임 누적 표결 불참률 카토그램"
       })
     ).toBeInTheDocument();
     const mapLegend = screen.getByLabelText(
-      "결석률 비교 단계. 실제 값과 전국 순위를 함께 확인할 수 있습니다."
+      "재임 누적 표결 불참률 비교 단계. 실제 값과 전국 순위를 함께 확인할 수 있습니다."
     );
     expect(
       within(mapLegend).getByText("1 낮음 · 전국 하위 50%")
@@ -185,7 +195,7 @@ describe("v2 observatory", () => {
     ).not.toBeInTheDocument();
     const proportionalComparison = screen
       .getByRole("heading", {
-        name: "출석 · 비례대표 의원 비교"
+        name: "표결 참여 · 비례대표 의원 비교"
       })
       .closest("section");
     expect(proportionalComparison).not.toBeNull();
@@ -208,6 +218,9 @@ describe("v2 observatory", () => {
       screen.getByRole("heading", {
         name: "표결 성향 · 비례대표 의원 비교"
       })
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("추세 범례")).getByText("확인 불가")
     ).toBeInTheDocument();
     expect(observatoryPanel).toHaveAttribute(
       "aria-labelledby",

--- a/tests/web/watch-queue-snapshot.test.tsx
+++ b/tests/web/watch-queue-snapshot.test.tsx
@@ -70,6 +70,28 @@ const trends: AccountabilityTrendsExport = {
   ]
 };
 
+const unresolvedTrends: AccountabilityTrendsExport = {
+  ...trends,
+  movers: [
+    {
+      ...trendBase,
+      memberId: "M004",
+      name: "확인불가",
+      party: "국민의힘",
+      previousWindowEligibleCount: 23,
+      previousWindowNoCount: 23,
+      previousWindowAbstainCount: 0,
+      previousWindowAbsentCount: 0,
+      previousWindowUnresolvedCount: 0,
+      currentWindowEligibleCount: 23,
+      currentWindowNoCount: 0,
+      currentWindowAbstainCount: 0,
+      currentWindowAbsentCount: 0,
+      currentWindowUnresolvedCount: 3
+    }
+  ]
+};
+
 describe("watch queue change language", () => {
   it("separates vote participation from yes, no, abstain, and absence", () => {
     render(
@@ -118,5 +140,23 @@ describe("watch queue change language", () => {
         })
         .closest("article")
     ).toHaveClass("is-absence-record");
+  });
+
+  it("does not infer a change when either comparison window is unresolved", () => {
+    render(
+      <WatchQueueSnapshot
+        accountabilitySummary={null}
+        accountabilityTrends={unresolvedTrends}
+        billProposalActivity={null}
+        loading={false}
+        unavailable={false}
+        onOpenMember={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("확인불가")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "전체 0건 중 0건 표시"
+    );
   });
 });


### PR DESCRIPTION
## Summary

- classify missing member-specific vote rows as unresolved instead of inferring absence from aggregate vote totals
- preserve only explicit absence records and propagate unresolved coverage through summaries, trends, rankings, maps, calendars, and member share metadata
- distinguish recorded-vote participation from committee and plenary meeting attendance throughout the UI
- suppress rates, rankings, map severity, and change signals when the relevant vote window is unresolved

## Lee So-hee verification

Using the published raw snapshot as the fixed input:

- previous output: 537 recorded votes, 537 inferred absences
- corrected output: 537 recorded votes, 0 explicit absences, 537 unresolved member rows
- committee participation rates: unavailable when no member-specific rows are resolved
- members incorrectly shown as absent for every recorded vote: 14 before, 0 after

## Validation

- `npm test` — 59 files, 279 tests passed
- `npm run lint` — passed
- `npm run typecheck` — passed
- production Vite build — passed
- member share generation against the fixed local published-data artifact — 298 pages generated successfully
- `git diff --check` — passed
