### PR TITLE
Fix minutes mirror retry dispatch

### DIFF
--- a/.github/workflows/mirror-documents.yml
+++ b/.github/workflows/mirror-documents.yml
@@ -184,6 +184,7 @@ jobs:
       - name: Retry failed minutes mirror
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           CURRENT_RETRY_ATTEMPT: ${{ inputs.retry_attempt || '0' }}
           MAX_RETRY_ATTEMPTS: "3"
           BACKFILL_START_DATE: ${{ inputs.backfill_start_date || '' }}

--- a/tests/ingest/minutes-incremental-workflow.test.ts
+++ b/tests/ingest/minutes-incremental-workflow.test.ts
@@ -24,6 +24,7 @@ describe("incremental minutes workflows", () => {
     expect(workflow).toContain("group: published-data-${{ vars.DATA_REPO");
     expect(workflow).toContain("queue: max");
     expect(workflow).toContain("Retry failed minutes mirror");
+    expect(workflow).toContain("GH_REPO: ${{ github.repository }}");
     expect(workflow).toContain('-f retry_attempt="0"');
   });
 


### PR DESCRIPTION
## What changed

Set `GH_REPO` explicitly in the failed-minutes-mirror retry job so `gh workflow run` can target this repository without a checked-out Git worktree.

## Root cause

The retry job intentionally has no checkout step. GitHub CLI therefore failed with `fatal: not a git repository` before it could enqueue the retry.

## Verification

- incremental minutes workflow tests passed
- Prettier check passed
- staged diff check passed
