### PR TITLE
Preserve manual minutes backfill window

### DIFF
--- a/.github/workflows/mirror-documents.yml
+++ b/.github/workflows/mirror-documents.yml
@@ -76,7 +76,7 @@ jobs:
       MIRROR_BACKFILL_DAYS: ${{ vars.MIRROR_BACKFILL_DAYS }}
       MIRROR_BACKFILL_CURSOR_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_start_date || '' }}
       MIRROR_BACKFILL_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_BACKFILL_WINDOWS_PER_RUN || '1' }}
-      MIRROR_CATCHUP_WINDOWS_PER_RUN: ${{ vars.MIRROR_CATCHUP_WINDOWS_PER_RUN || '2' }}
+      MIRROR_CATCHUP_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_CATCHUP_WINDOWS_PER_RUN || '2' }}
       MIRROR_SKIP_RECENT: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_recent || 'false' }}
       MIRROR_INCLUDE_APPENDICES: ${{ github.event_name == 'workflow_dispatch' && inputs.include_appendices || vars.MIRROR_INCLUDE_APPENDICES || 'false' }}
     steps:

--- a/tests/ingest/minutes-incremental-workflow.test.ts
+++ b/tests/ingest/minutes-incremental-workflow.test.ts
@@ -15,7 +15,7 @@ describe("incremental minutes workflows", () => {
 
     expect(workflow).toContain('default: "20"');
     expect(workflow).toContain(
-      "MIRROR_CATCHUP_WINDOWS_PER_RUN: ${{ vars.MIRROR_CATCHUP_WINDOWS_PER_RUN || '2' }}"
+      "MIRROR_CATCHUP_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_CATCHUP_WINDOWS_PER_RUN || '2' }}"
     );
     expect(workflow).toContain("timeout-minutes: 30");
     expect(workflow).toContain("Start minutes summaries");


### PR DESCRIPTION
## What changed

When a manually dispatched minutes backfill advances the cursor and schedules its continuation, preserve the selected `backfill_windows` size. Scheduled runs still use the repository variable or the existing two-window default.

## Why

A safe 20-window manual backfill should continue in 20-window chunks. Falling back to two windows repeats runner setup dozens of times and delays complete official attendance coverage.

## Verification

- incremental minutes workflow tests passed
- Prettier check passed
- diff check passed
