### PR TITLE
Scope named vote details to official recorded-vote summaries

### DIFF
--- a/packages/ingest/src/scripts/ingest-live.ts
+++ b/packages/ingest/src/scripts/ingest-live.ts
@@ -127,6 +127,34 @@ function countXmlRows(xml: string): number {
   return (xml.match(/<row>/g) ?? []).length;
 }
 
+export function validateRecordedVoteSummaryPage(args: {
+  page: number;
+  rawRowCount: number;
+  parsedRowCount: number;
+  publishedTotal: number | null;
+  expectedTotal: number | null;
+}): number {
+  if (args.publishedTotal === null) {
+    throw new Error(
+      `Official recorded-vote summary page ${args.page} has no published total.`
+    );
+  }
+  if (
+    args.expectedTotal !== null &&
+    args.publishedTotal !== args.expectedTotal
+  ) {
+    throw new Error(
+      `Official recorded-vote summary total changed on page ${args.page}: expected ${args.expectedTotal}, received ${args.publishedTotal}.`
+    );
+  }
+  if (args.parsedRowCount !== args.rawRowCount) {
+    throw new Error(
+      `Official recorded-vote summary page ${args.page} dropped rows during validation: raw ${args.rawRowCount}, parsed ${args.parsedRowCount}.`
+    );
+  }
+  return args.publishedTotal;
+}
+
 export function selectRecordedVoteBillRefs(args: {
   summaries: Array<{ billNo: string; billId: string }>;
   agendas: Array<{ billNo: string; billId?: string }>;
@@ -141,15 +169,15 @@ export function selectRecordedVoteBillRefs(args: {
       );
     }
     const existing = refsByBillNo.get(summary.billNo);
-    if (existing && existing.billId !== summary.billId) {
+    if (existing) {
       throw new Error(
-        `Official recorded-vote summaries conflict for bill ${summary.billNo}: ${existing.billId} and ${summary.billId}.`
+        `Official recorded-vote summaries contain duplicate bill ${summary.billNo}: ${existing.billId} and ${summary.billId}.`
       );
     }
     const existingBillNo = billNoByBillId.get(summary.billId);
-    if (existingBillNo && existingBillNo !== summary.billNo) {
+    if (existingBillNo) {
       throw new Error(
-        `Official recorded-vote summaries conflict for id ${summary.billId}: bills ${existingBillNo} and ${summary.billNo}.`
+        `Official recorded-vote summaries contain duplicate id ${summary.billId}: bills ${existingBillNo} and ${summary.billNo}.`
       );
     }
     refsByBillNo.set(summary.billNo, {
@@ -1164,25 +1192,33 @@ async function main(): Promise<void> {
       }
     });
     manifestEntries.push(result.entry);
-    billVoteSummaryRecords.push(...parseBillVoteSummaryXml(result.body));
-
+    const pageRecords = parseBillVoteSummaryXml(result.body);
     const rows = countXmlRows(result.body);
+    expectedBillVoteSummaryRows = validateRecordedVoteSummaryPage({
+      page,
+      rawRowCount: rows,
+      parsedRowCount: pageRecords.length,
+      publishedTotal: parseListTotalCount(result.body),
+      expectedTotal: expectedBillVoteSummaryRows
+    });
+    billVoteSummaryRecords.push(...pageRecords);
     fetchedBillVoteSummaryRows += rows;
-    expectedBillVoteSummaryRows ??= parseListTotalCount(result.body);
 
     if (rows === 0) {
       break;
     }
-    if (
-      expectedBillVoteSummaryRows !== null &&
-      fetchedBillVoteSummaryRows >= expectedBillVoteSummaryRows
-    ) {
+    if (fetchedBillVoteSummaryRows > expectedBillVoteSummaryRows) {
+      throw new Error(
+        `Bill vote summary paging exceeded the published total. Expected ${expectedBillVoteSummaryRows}, fetched ${fetchedBillVoteSummaryRows}.`
+      );
+    }
+    if (fetchedBillVoteSummaryRows === expectedBillVoteSummaryRows) {
       break;
     }
   }
   if (
     expectedBillVoteSummaryRows === null ||
-    fetchedBillVoteSummaryRows < expectedBillVoteSummaryRows
+    fetchedBillVoteSummaryRows !== expectedBillVoteSummaryRows
   ) {
     throw new Error(
       `Bill vote summary paging incomplete. Expected ${expectedBillVoteSummaryRows ?? "a published total"}, fetched ${fetchedBillVoteSummaryRows}.`

--- a/packages/ingest/src/scripts/ingest-live.ts
+++ b/packages/ingest/src/scripts/ingest-live.ts
@@ -127,6 +127,55 @@ function countXmlRows(xml: string): number {
   return (xml.match(/<row>/g) ?? []).length;
 }
 
+export function selectRecordedVoteBillRefs(args: {
+  summaries: Array<{ billNo: string; billId: string }>;
+  agendas: Array<{ billNo: string; billId?: string }>;
+}): Array<{ billNo: string; billId: string }> {
+  const refsByBillNo = new Map<string, { billNo: string; billId: string }>();
+  const billNoByBillId = new Map<string, string>();
+
+  for (const summary of args.summaries) {
+    if (!summary.billNo || !summary.billId) {
+      throw new Error(
+        "Official recorded-vote summary is missing BILL_NO or BILL_ID."
+      );
+    }
+    const existing = refsByBillNo.get(summary.billNo);
+    if (existing && existing.billId !== summary.billId) {
+      throw new Error(
+        `Official recorded-vote summaries conflict for bill ${summary.billNo}: ${existing.billId} and ${summary.billId}.`
+      );
+    }
+    const existingBillNo = billNoByBillId.get(summary.billId);
+    if (existingBillNo && existingBillNo !== summary.billNo) {
+      throw new Error(
+        `Official recorded-vote summaries conflict for id ${summary.billId}: bills ${existingBillNo} and ${summary.billNo}.`
+      );
+    }
+    refsByBillNo.set(summary.billNo, {
+      billNo: summary.billNo,
+      billId: summary.billId
+    });
+    billNoByBillId.set(summary.billId, summary.billNo);
+  }
+
+  for (const agenda of args.agendas) {
+    const recordedVote = refsByBillNo.get(agenda.billNo);
+    if (!recordedVote || !agenda.billId) {
+      continue;
+    }
+    if (recordedVote.billId !== agenda.billId) {
+      throw new Error(
+        `Official plenary agenda conflicts with recorded-vote summary for bill ${agenda.billNo}: ${agenda.billId} and ${recordedVote.billId}.`
+      );
+    }
+  }
+
+  return [...refsByBillNo.values()].sort((left, right) =>
+    left.billNo.localeCompare(right.billNo)
+  );
+}
+
 function sanitizeAssemblyRequestParams(
   config: AssemblyApiConfig,
   params: Record<string, string>
@@ -1177,15 +1226,10 @@ async function main(): Promise<void> {
     }
   ];
 
-  const billRefs = new Map<string, { billNo: string; billId?: string }>(
-    billVoteSummaryRecords.map((record) => [
-      record.billNo,
-      {
-        billNo: record.billNo,
-        billId: record.billId
-      }
-    ])
-  );
+  const plenaryAgendaBillRefs: Array<{
+    billNo: string;
+    billId?: string;
+  }> = [];
   const billResults = await mapWithConcurrency(
     billTargets,
     config.billFeedConcurrency,
@@ -1254,30 +1298,17 @@ async function main(): Promise<void> {
         continue;
       }
 
-      billRefs.set(billNo, {
+      plenaryAgendaBillRefs.push({
         billNo,
-        billId: agenda.billId ?? billRefs.get(billNo)?.billId
+        ...(agenda.billId ? { billId: agenda.billId } : {})
       });
     }
   }
 
-  const sortedBillRefs = [...billRefs.values()].sort((left, right) =>
-    left.billNo.localeCompare(right.billNo)
-  );
-  const missingBillIds = sortedBillRefs
-    .filter((item) => !item.billId)
-    .map((item) => item.billNo);
-
-  if (missingBillIds.length > 0) {
-    throw new Error(
-      `Official vote detail requires BILL_ID for every agenda. Missing BILL_ID for: ${missingBillIds.slice(0, 10).join(", ")}${missingBillIds.length > 10 ? "..." : ""}`
-    );
-  }
-
-  const verifiedBillRefs = sortedBillRefs as Array<{
-    billNo: string;
-    billId: string;
-  }>;
+  const verifiedBillRefs = selectRecordedVoteBillRefs({
+    summaries: billVoteSummaryRecords,
+    agendas: plenaryAgendaBillRefs
+  });
   const voteResults = await mapWithConcurrency(
     verifiedBillRefs,
     config.voteDetailConcurrency,

--- a/tests/ingest/assembly-api.test.ts
+++ b/tests/ingest/assembly-api.test.ts
@@ -7,6 +7,7 @@ import {
   buildVoteDetailRequest,
   resolveAssemblyApiConfig
 } from "../../packages/ingest/src/assembly-api.js";
+import { selectRecordedVoteBillRefs } from "../../packages/ingest/src/scripts/ingest-live.js";
 
 describe("assembly api request builder", () => {
   it("adds common params and includes the configured OpenAPI key in the query string", () => {
@@ -117,5 +118,64 @@ describe("assembly api request builder", () => {
     expect(directUrl.searchParams.get("pIndex")).toBe("1");
     expect(directUrl.searchParams.get("pSize")).toBe("20");
     expect(directUrl.searchParams.get("MONA_CD")).toBe("QUR40502");
+  });
+
+  it("requests named vote details only for official recorded-vote summaries", () => {
+    expect(
+      selectRecordedVoteBillRefs({
+        summaries: [
+          {
+            billNo: "2210001",
+            billId: "PRC_FIRST"
+          },
+          {
+            billNo: "2212345",
+            billId: "PRC_RECORDED"
+          },
+          {
+            billNo: "2212345",
+            billId: "PRC_RECORDED"
+          }
+        ],
+        agendas: [
+          {
+            billNo: "2212345",
+            billId: "PRC_RECORDED"
+          },
+          {
+            billNo: "2200013",
+            billId: "PRC_D2Q4S0G5I3K0X1S2I4L2M2D0B2H8Q2"
+          }
+        ]
+      })
+    ).toEqual([
+      {
+        billNo: "2210001",
+        billId: "PRC_FIRST"
+      },
+      {
+        billNo: "2212345",
+        billId: "PRC_RECORDED"
+      }
+    ]);
+  });
+
+  it("fails closed when official vote sources disagree on a bill id", () => {
+    expect(() =>
+      selectRecordedVoteBillRefs({
+        summaries: [
+          {
+            billNo: "2212345",
+            billId: "PRC_RECORDED"
+          }
+        ],
+        agendas: [
+          {
+            billNo: "2212345",
+            billId: "PRC_CONFLICT"
+          }
+        ]
+      })
+    ).toThrow(/conflicts with recorded-vote summary/);
   });
 });

--- a/tests/ingest/assembly-api.test.ts
+++ b/tests/ingest/assembly-api.test.ts
@@ -7,7 +7,10 @@ import {
   buildVoteDetailRequest,
   resolveAssemblyApiConfig
 } from "../../packages/ingest/src/assembly-api.js";
-import { selectRecordedVoteBillRefs } from "../../packages/ingest/src/scripts/ingest-live.js";
+import {
+  selectRecordedVoteBillRefs,
+  validateRecordedVoteSummaryPage
+} from "../../packages/ingest/src/scripts/ingest-live.js";
 
 describe("assembly api request builder", () => {
   it("adds common params and includes the configured OpenAPI key in the query string", () => {
@@ -131,10 +134,6 @@ describe("assembly api request builder", () => {
           {
             billNo: "2212345",
             billId: "PRC_RECORDED"
-          },
-          {
-            billNo: "2212345",
-            billId: "PRC_RECORDED"
           }
         ],
         agendas: [
@@ -177,5 +176,62 @@ describe("assembly api request builder", () => {
         ]
       })
     ).toThrow(/conflicts with recorded-vote summary/);
+  });
+
+  it("rejects incomplete or inconsistent recorded-vote summary pages", () => {
+    expect(
+      validateRecordedVoteSummaryPage({
+        page: 1,
+        rawRowCount: 1000,
+        parsedRowCount: 1000,
+        publishedTotal: 1656,
+        expectedTotal: null
+      })
+    ).toBe(1656);
+    expect(() =>
+      validateRecordedVoteSummaryPage({
+        page: 2,
+        rawRowCount: 656,
+        parsedRowCount: 655,
+        publishedTotal: 1656,
+        expectedTotal: 1656
+      })
+    ).toThrow(/dropped rows during validation/);
+    expect(() =>
+      validateRecordedVoteSummaryPage({
+        page: 2,
+        rawRowCount: 656,
+        parsedRowCount: 656,
+        publishedTotal: 1657,
+        expectedTotal: 1656
+      })
+    ).toThrow(/total changed/);
+    expect(() =>
+      validateRecordedVoteSummaryPage({
+        page: 1,
+        rawRowCount: 0,
+        parsedRowCount: 0,
+        publishedTotal: null,
+        expectedTotal: null
+      })
+    ).toThrow(/no published total/);
+  });
+
+  it("rejects duplicate official recorded-vote summaries", () => {
+    expect(() =>
+      selectRecordedVoteBillRefs({
+        summaries: [
+          {
+            billNo: "2212345",
+            billId: "PRC_RECORDED"
+          },
+          {
+            billNo: "2212345",
+            billId: "PRC_RECORDED"
+          }
+        ],
+        agendas: []
+      })
+    ).toThrow(/duplicate bill/);
   });
 });


### PR DESCRIPTION
## Summary
- use the fully paged official recorded-vote summary feed as the authoritative target set for member-level vote details
- keep plenary agenda feeds for metadata and fail-closed cross-checks without treating withdrawn or non-recorded agenda items as named votes
- require page totals to remain consistent, raw rows to equal parsed rows, final rows to exactly equal the published total, and BILL_NO/BILL_ID values to be unique

## Incident evidence
- failed bill `2200013` (`PRC_D2Q4S0G5I3K0X1S2I4L2M2D0B2H8Q2`) is officially marked withdrawn on 2025-04-24
- it is absent from the 1,656 official recorded-vote summaries and the prior 1,361 vote-detail targets
- prior artifact comparison found no nonempty vote-detail record outside the official recorded-vote summary set

## Verification
- 62 test files / 312 tests passed
- typecheck, lint, formatting, and production build passed

All runtime sources remain official National Assembly services only.