### PR TITLE
fix: trust official recorded-vote identifiers

### DIFF
--- a/packages/ingest/src/scripts/ingest-live.ts
+++ b/packages/ingest/src/scripts/ingest-live.ts
@@ -22,7 +22,6 @@ import {
 } from "../member-history-backfill.js";
 import { enrichMembersWithMemberProfileAll } from "../member-profile-enrichment.js";
 import {
-  parseAgendaXml,
   parseBillVoteSummaryXml,
   parseMemberInfoXml,
   parseMemberProfileAllXml,
@@ -157,7 +156,6 @@ export function validateRecordedVoteSummaryPage(args: {
 
 export function selectRecordedVoteBillRefs(args: {
   summaries: Array<{ billNo: string; billId: string }>;
-  agendas: Array<{ billNo: string; billId?: string }>;
 }): Array<{ billNo: string; billId: string }> {
   const refsByBillNo = new Map<string, { billNo: string; billId: string }>();
   const billNoByBillId = new Map<string, string>();
@@ -185,18 +183,6 @@ export function selectRecordedVoteBillRefs(args: {
       billId: summary.billId
     });
     billNoByBillId.set(summary.billId, summary.billNo);
-  }
-
-  for (const agenda of args.agendas) {
-    const recordedVote = refsByBillNo.get(agenda.billNo);
-    if (!recordedVote || !agenda.billId) {
-      continue;
-    }
-    if (recordedVote.billId !== agenda.billId) {
-      throw new Error(
-        `Official plenary agenda conflicts with recorded-vote summary for bill ${agenda.billNo}: ${agenda.billId} and ${recordedVote.billId}.`
-      );
-    }
   }
 
   return [...refsByBillNo.values()].sort((left, right) =>
@@ -1262,10 +1248,6 @@ async function main(): Promise<void> {
     }
   ];
 
-  const plenaryAgendaBillRefs: Array<{
-    billNo: string;
-    billId?: string;
-  }> = [];
   const billResults = await mapWithConcurrency(
     billTargets,
     config.billFeedConcurrency,
@@ -1321,29 +1303,13 @@ async function main(): Promise<void> {
 
   for (const result of billResults.flat()) {
     manifestEntries.push(result.entry);
-
-    const parsed = parseAgendaXml(result.body, {
-      sourceUrl: result.entry.sourceUrl,
-      retrievedAt: result.entry.retrievedAt,
-      snapshotId
-    });
-
-    for (const agenda of parsed.agendas) {
-      const billNo = agenda.agendaId;
-      if (!billNo) {
-        continue;
-      }
-
-      plenaryAgendaBillRefs.push({
-        billNo,
-        ...(agenda.billId ? { billId: agenda.billId } : {})
-      });
-    }
   }
 
+  // The recorded-vote feed can publish a different BILL_ID from the plenary
+  // agenda feed for the same BILL_NO. Its BILL_ID is the canonical identifier
+  // for the member-level vote API and the official LIKMS vote page.
   const verifiedBillRefs = selectRecordedVoteBillRefs({
-    summaries: billVoteSummaryRecords,
-    agendas: plenaryAgendaBillRefs
+    summaries: billVoteSummaryRecords
   });
   const voteResults = await mapWithConcurrency(
     verifiedBillRefs,

--- a/tests/ingest/assembly-api.test.ts
+++ b/tests/ingest/assembly-api.test.ts
@@ -124,30 +124,20 @@ describe("assembly api request builder", () => {
   });
 
   it("requests named vote details only for official recorded-vote summaries", () => {
-    expect(
-      selectRecordedVoteBillRefs({
-        summaries: [
-          {
-            billNo: "2210001",
-            billId: "PRC_FIRST"
-          },
-          {
-            billNo: "2212345",
-            billId: "PRC_RECORDED"
-          }
-        ],
-        agendas: [
-          {
-            billNo: "2212345",
-            billId: "PRC_RECORDED"
-          },
-          {
-            billNo: "2200013",
-            billId: "PRC_D2Q4S0G5I3K0X1S2I4L2M2D0B2H8Q2"
-          }
-        ]
-      })
-    ).toEqual([
+    const refs = selectRecordedVoteBillRefs({
+      summaries: [
+        {
+          billNo: "2210001",
+          billId: "PRC_FIRST"
+        },
+        {
+          billNo: "2212345",
+          billId: "PRC_RECORDED"
+        }
+      ]
+    });
+
+    expect(refs).toEqual([
       {
         billNo: "2210001",
         billId: "PRC_FIRST"
@@ -157,25 +147,26 @@ describe("assembly api request builder", () => {
         billId: "PRC_RECORDED"
       }
     ]);
+    expect(refs.map((ref) => ref.billId)).not.toContain(
+      "PRC_D2Q4S0G5I3K0X1S2I4L2M2D0B2H8Q2"
+    );
   });
 
-  it("fails closed when official vote sources disagree on a bill id", () => {
+  it("fails closed when a recorded-vote id is reused for another bill", () => {
     expect(() =>
       selectRecordedVoteBillRefs({
         summaries: [
           {
             billNo: "2212345",
             billId: "PRC_RECORDED"
-          }
-        ],
-        agendas: [
+          },
           {
-            billNo: "2212345",
-            billId: "PRC_CONFLICT"
+            billNo: "2212346",
+            billId: "PRC_RECORDED"
           }
         ]
       })
-    ).toThrow(/conflicts with recorded-vote summary/);
+    ).toThrow(/duplicate id/);
   });
 
   it("rejects incomplete or inconsistent recorded-vote summary pages", () => {
@@ -229,8 +220,7 @@ describe("assembly api request builder", () => {
             billNo: "2212345",
             billId: "PRC_RECORDED"
           }
-        ],
-        agendas: []
+        ]
       })
     ).toThrow(/duplicate bill/);
   });


### PR DESCRIPTION
## Summary

- use the fully paged and validated official recorded-vote summary as the sole identifier source for member-level vote detail requests
- keep all official plenary agenda feeds and manifests, but do not treat their alternative `BILL_ID` values as vote-detail identifiers
- preserve fail-closed validation for published totals, raw/parsed row parity, and unique bill numbers and identifiers

## Official evidence

The 2026-08-01 official snapshot contains 25 bills where the plenary agenda and recorded-vote summary publish different `BILL_ID` values for the same `BILL_NO`. For bill 2216968, the recorded-vote summary identifier resolves through the official member-vote API and LIKMS page, while the agenda identifier returns official `INFO-200` (no data). The recorded-vote summary identifier is therefore canonical for this API boundary.

## Verification

- 62 test files / 312 tests passed
- production build passed and generated 298 member share pages
- independent release audit found no blocking issue
- runtime sources remain limited to official National Assembly and government services