### PR TITLE
Fix duplicate vote identities and minutes cache validation

### DIFF
--- a/packages/ingest/src/official-attendance.ts
+++ b/packages/ingest/src/official-attendance.ts
@@ -131,13 +131,17 @@ function readSectionNames(html: string, sectionPattern: RegExp): string[] {
     heading.text().match(/\((\d+)인\)/)?.[1] ?? "",
     10
   );
-  if (Number.isFinite(publishedCount) && publishedCount !== names.length) {
+  const uniqueNames = [...new Set(names)];
+  if (
+    Number.isFinite(publishedCount) &&
+    (publishedCount !== names.length || publishedCount !== uniqueNames.length)
+  ) {
     throw new Error(
-      `Official minutes attendance list count mismatch: heading ${publishedCount}, parsed ${names.length}.`
+      `Official minutes attendance list count mismatch: heading ${publishedCount}, parsed ${names.length}, unique ${uniqueNames.length}.`
     );
   }
 
-  return [...new Set(names)];
+  return uniqueNames;
 }
 
 export function parseOfficialMinutesAttendanceHtml(html: string): {

--- a/packages/ingest/src/official-facts.ts
+++ b/packages/ingest/src/official-facts.ts
@@ -103,6 +103,7 @@ function buildCurrentMemberResolvers(
       memberName: string | null | undefined;
       officialProfileUrl?: string | null;
       voteDate: string;
+      excludedMemberIds?: ReadonlySet<string>;
     }): MemberRecord | null {
       const profileKey = normalizeOfficialProfileUrl(args.officialProfileUrl);
       const profileCandidates = profileKey
@@ -123,11 +124,20 @@ function buildCurrentMemberResolvers(
       if (!nameKey) {
         return null;
       }
-      const nameCandidates = (byName.get(nameKey) ?? []).filter((member) =>
-        isDateWithinTenure(args.voteDate, member.memberId, tenureIndex)
+      const eligibleNameCandidates = (byName.get(nameKey) ?? []).filter(
+        (member) =>
+          isDateWithinTenure(args.voteDate, member.memberId, tenureIndex)
+      );
+      const nameCandidates = eligibleNameCandidates.filter(
+        (member) => !args.excludedMemberIds?.has(member.memberId)
       );
       if (nameCandidates.length === 1) {
         return nameCandidates[0] ?? null;
+      }
+      if (eligibleNameCandidates.length > 0 && nameCandidates.length === 0) {
+        throw new Error(
+          `Official vote member name conflicts with already identified rows on ${args.voteDate}: ${args.memberName}.`
+        );
       }
       if (nameCandidates.length > 1) {
         throw new Error(
@@ -279,29 +289,54 @@ export function mergeOfficialVoteFacts(args: {
         )
         .map((member) => member.memberId)
     );
+    const explicitNonparticipantMemberIds = new Set(
+      voteFacts
+        .filter(
+          (fact) =>
+            fact.rollCallId === rollCall.rollCallId &&
+            fact.voteCode === "absent" &&
+            fact.memberId &&
+            currentMemberIds.has(fact.memberId)
+        )
+        .map((fact) => fact.memberId as string)
+    );
     voteFacts = voteFacts.filter((fact) => {
       if (fact.rollCallId !== rollCall.rollCallId) {
         return true;
+      }
+      if (fact.memberId) {
+        return !currentMemberIds.has(fact.memberId);
       }
       const member = resolver.resolve({
         memberName: fact.memberName,
         voteDate
       });
-      return !(
-        (fact.memberId && currentMemberIds.has(fact.memberId)) ||
-        (member && currentMemberIds.has(member.memberId))
-      );
+      return !(member && currentMemberIds.has(member.memberId));
     });
 
-    for (const record of info.records) {
+    const reservedMemberIds = new Set(explicitNonparticipantMemberIds);
+    const identityOrderedRecords = [...info.records].sort(
+      (left, right) =>
+        Number(Boolean(normalizeOfficialProfileUrl(right.officialProfileUrl))) -
+        Number(Boolean(normalizeOfficialProfileUrl(left.officialProfileUrl)))
+    );
+
+    for (const record of identityOrderedRecords) {
       const member = resolver.resolve({
         memberName: record.memberName,
         officialProfileUrl: record.officialProfileUrl,
-        voteDate
+        voteDate,
+        excludedMemberIds: reservedMemberIds
       });
       if (!member) {
         continue;
       }
+      if (reservedMemberIds.has(member.memberId)) {
+        throw new Error(
+          `Official vote sources assign conflicting rows to ${member.memberId} for ${rollCall.rollCallId}.`
+        );
+      }
+      reservedMemberIds.add(member.memberId);
 
       voteFacts.push({
         rollCallId: rollCall.rollCallId,

--- a/packages/ingest/src/scripts/mirror-documents.ts
+++ b/packages/ingest/src/scripts/mirror-documents.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { load } from "cheerio";
 import {
   chromium,
   request,
@@ -36,6 +37,7 @@ import {
   isOfficialAssemblyMinutesViewerUrl,
   parseAssemblyMinutesViewerHtml
 } from "../minutes-transcript.js";
+import { parseOfficialMinutesAttendanceHtml } from "../official-attendance.js";
 import {
   readJsonFile,
   readPositiveInteger,
@@ -1812,6 +1814,178 @@ async function downloadDocument(
   );
 }
 
+function readExpectedMinutesId(args: {
+  sourceUrl: string;
+  sourceMetadata?: Record<string, string | number | null>;
+}): string {
+  const minutesId =
+    readString(args.sourceMetadata?.minutesId) ??
+    new URL(args.sourceUrl).searchParams.get("id");
+  if (!minutesId) {
+    throw new Error(
+      `Official Assembly minutes artifact has no expected meeting id: ${args.sourceUrl}.`
+    );
+  }
+  return minutesId;
+}
+
+function assertOfficialMinutesAttendanceIsComplete(html: string): void {
+  const attendance = parseOfficialMinutesAttendanceHtml(html);
+  if (attendance.presentNames.length === 0) {
+    throw new Error(
+      "Official Assembly minutes artifact contains no verified attendance list."
+    );
+  }
+}
+
+export function assertAssemblyMinutesViewerPayloadMatchesCandidate(args: {
+  html: string;
+  sourceUrl: string;
+  responseUrl?: string;
+  expectedMinutesId: string;
+  expectedMeetingDate: string;
+}): void {
+  if (!isOfficialAssemblyMinutesViewerUrl(args.sourceUrl)) {
+    throw new Error(
+      `Official Assembly minutes viewer validation received an invalid source URL: ${args.sourceUrl}.`
+    );
+  }
+  if (
+    args.responseUrl &&
+    (!isOfficialAssemblyMinutesViewerUrl(args.responseUrl) ||
+      new URL(args.responseUrl).searchParams.get("id") !==
+        args.expectedMinutesId)
+  ) {
+    throw new Error(
+      `Official Assembly minutes viewer returned an unexpected response URL for ${args.expectedMinutesId}: ${args.responseUrl}.`
+    );
+  }
+
+  const embeddedMinutesIds = [
+    ...args.html.matchAll(
+      /\b(?:const|let|var)\s+mnts_id\s*=\s*["']?(\d+)["']?/g
+    )
+  ].flatMap((match) => (match[1] ? [match[1]] : []));
+  const uniqueMinutesIds = [...new Set(embeddedMinutesIds)];
+  if (
+    uniqueMinutesIds.length !== 1 ||
+    uniqueMinutesIds[0] !== args.expectedMinutesId
+  ) {
+    throw new Error(
+      `Official Assembly minutes viewer payload id mismatch: expected ${args.expectedMinutesId}, received ${uniqueMinutesIds.join(", ") || "(missing)"}.`
+    );
+  }
+
+  const $ = load(args.html);
+  const meetingDates = [
+    $("#header h2 .date").first().text(),
+    $(".minutes_header .place .con").first().text()
+  ]
+    .map((value) => normalizeDocumentDate(value))
+    .filter((value): value is string => Boolean(value));
+  const uniqueMeetingDates = [...new Set(meetingDates)];
+  if (
+    uniqueMeetingDates.length !== 1 ||
+    uniqueMeetingDates[0] !== args.expectedMeetingDate
+  ) {
+    throw new Error(
+      `Official Assembly minutes viewer payload date mismatch for ${args.expectedMinutesId}: expected ${args.expectedMeetingDate}, received ${uniqueMeetingDates.join(", ") || "(missing)"}.`
+    );
+  }
+
+  assertOfficialMinutesAttendanceIsComplete(args.html);
+}
+
+export function assertAssemblyMinutesSearchFallbackPayloadMatchesCandidate(args: {
+  html: string;
+  expectedMinutesId: string;
+  expectedMeetingDate: string;
+  expectedClassCode?: string;
+}): void {
+  const $ = load(args.html);
+  const sourceUrl = $('meta[name="official-search-source"]')
+    .first()
+    .attr("content");
+  let parsedSourceUrl: URL;
+  try {
+    parsedSourceUrl = new URL(sourceUrl ?? "");
+  } catch {
+    throw new Error(
+      `Official Assembly minutes search fallback has no valid source URL for ${args.expectedMinutesId}.`
+    );
+  }
+  if (
+    parsedSourceUrl.origin !== officialAssemblyMinutesOrigin ||
+    parsedSourceUrl.pathname !== "/assembly/mnts/search/search.do"
+  ) {
+    throw new Error(
+      `Official Assembly minutes search fallback has an unexpected source URL for ${args.expectedMinutesId}: ${sourceUrl ?? "(missing)"}.`
+    );
+  }
+
+  const embeddedRows = $("#official-search-rows").first().text();
+  let rows: AssemblySearchItem[];
+  try {
+    const parsedRows = JSON.parse(embeddedRows) as unknown;
+    if (!Array.isArray(parsedRows) || parsedRows.length === 0) {
+      throw new Error("missing rows");
+    }
+    rows = parsedRows as AssemblySearchItem[];
+  } catch {
+    throw new Error(
+      `Official Assembly minutes search fallback has no complete embedded rows for ${args.expectedMinutesId}.`
+    );
+  }
+
+  for (const row of rows) {
+    const minutesId = readString(row.MNTS_ID);
+    const meetingDate = normalizeCompactAssemblyDate(
+      readString(row.DATE) ?? readString(row.RDATE)
+    );
+    const classCode = readString(row.CLASS_CD);
+    if (
+      minutesId !== args.expectedMinutesId ||
+      meetingDate !== args.expectedMeetingDate ||
+      (args.expectedClassCode && classCode !== args.expectedClassCode)
+    ) {
+      throw new Error(
+        `Official Assembly minutes search fallback embedded row mismatch for ${args.expectedMinutesId}.`
+      );
+    }
+  }
+
+  assertOfficialMinutesAttendanceIsComplete(args.html);
+}
+
+function assertMirroredAssemblyMinutesArtifact(args: {
+  body: Buffer;
+  sourceUrl: string;
+  responseUrl?: string;
+  publishedDate: string;
+  sourceMetadata?: Record<string, string | number | null>;
+}): void {
+  const html = args.body.toString("utf8");
+  const expectedMinutesId = readExpectedMinutesId(args);
+  const retrievalMethod = readString(args.sourceMetadata?.retrievalMethod);
+  if (retrievalMethod === "official_minutes_search_api_fallback") {
+    assertAssemblyMinutesSearchFallbackPayloadMatchesCandidate({
+      html,
+      expectedMinutesId,
+      expectedMeetingDate: args.publishedDate,
+      expectedClassCode: readString(args.sourceMetadata?.classCode)
+    });
+    return;
+  }
+
+  assertAssemblyMinutesViewerPayloadMatchesCandidate({
+    html,
+    sourceUrl: args.sourceUrl,
+    responseUrl: args.responseUrl,
+    expectedMinutesId,
+    expectedMeetingDate: args.publishedDate
+  });
+}
+
 async function downloadAssemblyMinutesSearchFallback(args: {
   api: APIRequestContext;
   candidate: MirrorCandidate;
@@ -1890,6 +2064,23 @@ async function mirrorCandidate(
   let downloaded: DownloadedDocument;
   try {
     downloaded = await downloadDocument(api, downloadTarget, config.timeoutMs);
+    if (
+      config.mode === "assembly_minutes_catalog" &&
+      isOfficialAssemblyMinutesViewerUrl(candidate.sourceUrl)
+    ) {
+      if (!candidate.publishedDate) {
+        throw new Error(
+          "Official Assembly minutes candidate has no published date."
+        );
+      }
+      assertMirroredAssemblyMinutesArtifact({
+        body: downloaded.body,
+        sourceUrl: candidate.sourceUrl,
+        responseUrl: downloaded.responseUrl,
+        publishedDate: candidate.publishedDate,
+        sourceMetadata: candidate.sourceMetadata
+      });
+    }
   } catch (downloadError) {
     if (
       config.mode !== "assembly_minutes_catalog" ||
@@ -1905,6 +2096,20 @@ async function mirrorCandidate(
         api,
         candidate,
         config
+      });
+      if (!candidate.publishedDate) {
+        throw new Error(
+          "Official Assembly minutes fallback candidate has no published date."
+        );
+      }
+      assertMirroredAssemblyMinutesArtifact({
+        body: downloaded.body,
+        sourceUrl: candidate.sourceUrl,
+        publishedDate: candidate.publishedDate,
+        sourceMetadata: {
+          ...candidate.sourceMetadata,
+          ...downloaded.sourceMetadata
+        }
       });
     } catch (fallbackError) {
       throw new AggregateError(
@@ -2214,14 +2419,35 @@ export async function mirroredDocumentMatchesMetadata(
   metadata: Pick<
     MirroredDocumentMetadata,
     "latestRelativePath" | "currentBytes" | "currentContentSha256"
-  >
+  > &
+    Partial<
+      Pick<
+        MirroredDocumentMetadata,
+        "sourceUrl" | "publishedDate" | "sourceMetadata"
+      >
+    >
 ): Promise<boolean> {
   try {
     const body = await readFile(join(dataRepoDir, metadata.latestRelativePath));
-    return (
-      body.byteLength === metadata.currentBytes &&
-      sha256Buffer(body) === metadata.currentContentSha256
-    );
+    if (
+      body.byteLength !== metadata.currentBytes ||
+      sha256Buffer(body) !== metadata.currentContentSha256
+    ) {
+      return false;
+    }
+    if (
+      metadata.sourceUrl &&
+      metadata.publishedDate &&
+      isOfficialAssemblyMinutesViewerUrl(metadata.sourceUrl)
+    ) {
+      assertMirroredAssemblyMinutesArtifact({
+        body,
+        sourceUrl: metadata.sourceUrl,
+        publishedDate: metadata.publishedDate,
+        sourceMetadata: metadata.sourceMetadata
+      });
+    }
+    return true;
   } catch {
     return false;
   }

--- a/tests/ingest/document-mirror.test.ts
+++ b/tests/ingest/document-mirror.test.ts
@@ -25,6 +25,8 @@ import {
   splitAssemblySearchWindowsByDay
 } from "../../packages/ingest/src/assembly-mirror-policy.js";
 import {
+  assertAssemblyMinutesSearchFallbackPayloadMatchesCandidate,
+  assertAssemblyMinutesViewerPayloadMatchesCandidate,
   assertAssemblySearchResponsesComplete,
   buildAssemblyFileServiceSourceSnapshot,
   buildAssemblyMinutesCatalogCandidate,
@@ -48,6 +50,41 @@ import { parseOfficialMinutesAttendanceHtml } from "../../packages/ingest/src/of
 import { parseAssemblyMinutesViewerHtml } from "../../packages/ingest/src/minutes-transcript.js";
 import { buildMinutesSummaryGroups } from "../../packages/ingest/src/minutes-summarization.js";
 import { sha256Buffer } from "../../packages/ingest/src/utils.js";
+
+function buildViewerIntegrityFixture(args?: {
+  minutesId?: string;
+  meetingDate?: string;
+  publishedCount?: number;
+  names?: string[];
+}): string {
+  const minutesId = args?.minutesId ?? "57073";
+  const meetingDate = args?.meetingDate ?? "2026.07.30";
+  const names = args?.names ?? ["이소희", "김위원"];
+  const publishedCount = args?.publishedCount ?? names.length;
+  const [year, month, day] = meetingDate.split(".");
+  return `
+    <div id="header">
+      <h2><span class="date">(${meetingDate}.)</span></h2>
+    </div>
+    <div class="minutes_header">
+      <div class="place"><p class="con">${year}년 ${month}월 ${day}일</p></div>
+    </div>
+    <div class="minutes_footer">
+      <div class="list">
+        <p><strong>◯출석 위원(${publishedCount}인)</strong></p>
+        <div class="con">
+          ${names
+            .map(
+              (name, index) =>
+                `<a href="/members/member-${index}"><span class="name">${name}</span></a>`
+            )
+            .join("")}
+        </div>
+      </div>
+    </div>
+    <script>const mnts_id = ${minutesId};</script>
+  `;
+}
 
 describe("document mirror helpers", () => {
   it("keeps the recent safety floor for both official minutes collectors", () => {
@@ -145,6 +182,96 @@ describe("document mirror helpers", () => {
       await rm(path);
       await expect(
         mirroredDocumentMatchesMetadata(root, metadata)
+      ).resolves.toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("validates the official viewer meeting identity, date, and attendance", () => {
+    const sourceUrl =
+      "https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?id=57073&type=view";
+    const validHtml = buildViewerIntegrityFixture();
+
+    expect(() =>
+      assertAssemblyMinutesViewerPayloadMatchesCandidate({
+        html: validHtml,
+        sourceUrl,
+        responseUrl: sourceUrl,
+        expectedMinutesId: "57073",
+        expectedMeetingDate: "2026-07-30"
+      })
+    ).not.toThrow();
+    expect(() =>
+      assertAssemblyMinutesViewerPayloadMatchesCandidate({
+        html: buildViewerIntegrityFixture({ minutesId: "57054" }),
+        sourceUrl,
+        expectedMinutesId: "57073",
+        expectedMeetingDate: "2026-07-30"
+      })
+    ).toThrow(/payload id mismatch/);
+    expect(() =>
+      assertAssemblyMinutesViewerPayloadMatchesCandidate({
+        html: buildViewerIntegrityFixture({
+          meetingDate: "2026.07.29"
+        }),
+        sourceUrl,
+        expectedMinutesId: "57073",
+        expectedMeetingDate: "2026-07-30"
+      })
+    ).toThrow(/payload date mismatch/);
+    expect(() =>
+      assertAssemblyMinutesViewerPayloadMatchesCandidate({
+        html: buildViewerIntegrityFixture({
+          publishedCount: 2,
+          names: ["이소희"]
+        }),
+        sourceUrl,
+        expectedMinutesId: "57073",
+        expectedMeetingDate: "2026-07-30"
+      })
+    ).toThrow(/attendance list count mismatch/);
+    expect(() =>
+      assertAssemblyMinutesViewerPayloadMatchesCandidate({
+        html: buildViewerIntegrityFixture({
+          publishedCount: 2,
+          names: ["이소희", "이소희"]
+        }),
+        sourceUrl,
+        expectedMinutesId: "57073",
+        expectedMeetingDate: "2026-07-30"
+      })
+    ).toThrow(/unique 1/);
+  });
+
+  it("does not reuse a hash-valid official viewer cached under the wrong meeting", async () => {
+    const root = await mkdtemp(
+      join(tmpdir(), "document-mirror-semantic-reuse-")
+    );
+    try {
+      const relativePath = "raw/assembly-minutes/57073/latest.html";
+      const path = join(root, relativePath);
+      const body = Buffer.from(
+        buildViewerIntegrityFixture({ minutesId: "57054" })
+      );
+      await mkdir(join(root, "raw/assembly-minutes/57073"), {
+        recursive: true
+      });
+      await writeFile(path, body);
+
+      await expect(
+        mirroredDocumentMatchesMetadata(root, {
+          latestRelativePath: relativePath,
+          currentBytes: body.byteLength,
+          currentContentSha256: sha256Buffer(body),
+          sourceUrl:
+            "https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?id=57073&type=view",
+          publishedDate: "2026-07-30",
+          sourceMetadata: {
+            minutesId: "57073",
+            classCode: "2"
+          }
+        })
       ).resolves.toBe(false);
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -946,6 +1073,22 @@ describe("document mirror helpers", () => {
     ]);
     expect(html).toContain("official-search-rows");
     expect(html).toContain(sourceUrl);
+    expect(() =>
+      assertAssemblyMinutesSearchFallbackPayloadMatchesCandidate({
+        html,
+        expectedMinutesId: "52713",
+        expectedMeetingDate: "2025-02-26",
+        expectedClassCode: "2"
+      })
+    ).not.toThrow();
+    expect(() =>
+      assertAssemblyMinutesSearchFallbackPayloadMatchesCandidate({
+        html: html.replace('"MNTS_ID":"52713"', '"MNTS_ID":"52714"'),
+        expectedMinutesId: "52713",
+        expectedMeetingDate: "2025-02-26",
+        expectedClassCode: "2"
+      })
+    ).toThrow(/embedded row mismatch/);
   });
 
   it("separates official search speaker names from their roles", () => {

--- a/tests/ingest/official-facts.test.ts
+++ b/tests/ingest/official-facts.test.ts
@@ -4,6 +4,7 @@ import {
   buildOfficialAttendanceFacts,
   mergeOfficialVoteFacts
 } from "../../packages/ingest/src/official-facts.js";
+import { buildMeetingId } from "../../packages/ingest/src/parsers/helpers.js";
 
 import type { BillVoteSummaryRecord } from "../../packages/ingest/src/parsers.js";
 import type { RawSnapshotEntry } from "../../packages/ingest/src/raw-snapshot.js";
@@ -38,6 +39,30 @@ const kim: MemberRecord = {
   assemblyNo: 22
 };
 
+const seniorPark: MemberRecord = {
+  memberId: "8BF5855P",
+  name: "박지원",
+  party: "더불어민주당",
+  district: "전남광주통합특별시 해남군완도군진도군",
+  committeeMemberships: [],
+  officialProfileUrl: "https://www.assembly.go.kr/members/22nd/PARKJIEWON",
+  isCurrentMember: true,
+  proportionalFlag: false,
+  assemblyNo: 22
+};
+
+const newPark: MemberRecord = {
+  memberId: "H7X3372O",
+  name: "박지원",
+  party: "더불어민주당",
+  district: "전북 군산시김제시부안군을",
+  committeeMemberships: [],
+  officialProfileUrl: "https://www.assembly.go.kr/members/22nd/PARKJIWON",
+  isCurrentMember: true,
+  proportionalFlag: false,
+  assemblyNo: 22
+};
+
 const tenureIndex: MemberTenureIndex = new Map([
   [
     lee.memberId,
@@ -53,6 +78,24 @@ const tenureIndex: MemberTenureIndex = new Map([
     [
       {
         startDate: "2024-05-30",
+        endDate: null
+      }
+    ]
+  ],
+  [
+    seniorPark.memberId,
+    [
+      {
+        startDate: "2024-05-30",
+        endDate: null
+      }
+    ]
+  ],
+  [
+    newPark.memberId,
+    [
+      {
+        startDate: "2026-06-04",
         endDate: null
       }
     ]
@@ -223,6 +266,221 @@ describe("official vote fact completion", () => {
         (rollCall) => rollCall.officialTally?.presentCount === 1
       )
     ).toBe(true);
+  });
+
+  it("uses an official identified nonparticipant to resolve a same-name LIKMS voter", () => {
+    const date = "2026-07-23";
+    const source = buildVoteSource({
+      billId: "PRC_DUPLICATE_NAME",
+      billNo: "2219999",
+      date,
+      voteCode: "yes",
+      member: newPark
+    });
+    const rollCallId = `${buildMeetingId({
+      assemblyNo: 22,
+      sessionNo: 0,
+      meetingNo: 0,
+      meetingDate: date
+    })}:${source.summary.billId}`;
+    const merged = mergeOfficialVoteFacts({
+      members: [seniorPark, newPark],
+      rollCalls: [],
+      voteFacts: [
+        {
+          rollCallId,
+          memberId: seniorPark.memberId,
+          memberName: seniorPark.name,
+          party: seniorPark.party,
+          voteCode: "absent",
+          publishedAt: date,
+          retrievedAt: "2026-08-02T00:00:00.000Z",
+          sourceHash: "official-openapi-absence"
+        }
+      ],
+      summaries: [source.summary],
+      voteMemberListPayloads: [
+        {
+          entry: source.entry,
+          html: source.html.replace(
+            newPark.officialProfileUrl ?? "",
+            "javascript:void(0);"
+          )
+        }
+      ],
+      assemblyNo: 22,
+      snapshotId: "official-duplicate-name-fixture",
+      snapshotRetrievedAt: "2026-08-02T00:00:00.000Z",
+      tenureIndex
+    });
+
+    expect(
+      merged.voteFacts
+        .filter((fact) => fact.rollCallId === rollCallId)
+        .map((fact) => [fact.memberId, fact.voteCode])
+        .sort()
+    ).toEqual([
+      [seniorPark.memberId, "absent"],
+      [newPark.memberId, "yes"]
+    ]);
+  });
+
+  it("resolves unlinked same-name voters after profile-linked voters", () => {
+    const date = "2026-06-18";
+    const source = buildVoteSource({
+      billId: "PRC_TWO_DUPLICATE_NAMES",
+      billNo: "2219997",
+      date,
+      voteCode: "yes",
+      member: seniorPark
+    });
+    const rollCallId = `${buildMeetingId({
+      assemblyNo: 22,
+      sessionNo: 0,
+      meetingNo: 0,
+      meetingDate: date
+    })}:${source.summary.billId}`;
+    const html = `
+      <input name="billId" value="${source.summary.billId}" />
+      <input id="voteBillNo" value="${source.summary.billNo}" />
+      <input id="voteBillName" value="${source.summary.billName}" />
+      <p id="procDt">의결일 ${date}</p>
+      <p id="memberTcnt">재적 300인 재석 2인</p>
+      <p id="voteTcnt">찬성 2인 반대 0인 기권 0인</p>
+      <ul id="voteAgreeList">
+        <li><a href="javascript:void(0);"><p>${newPark.name}</p></a></li>
+        <li><a href="${seniorPark.officialProfileUrl}"><p>${seniorPark.name}</p></a></li>
+      </ul>
+      <ul id="voteDisAgreeList"></ul>
+      <ul id="voteAbsList"></ul>
+    `;
+    const merged = mergeOfficialVoteFacts({
+      members: [seniorPark, newPark],
+      rollCalls: [],
+      voteFacts: [
+        {
+          rollCallId,
+          memberId: seniorPark.memberId,
+          memberName: seniorPark.name,
+          party: seniorPark.party,
+          voteCode: "yes",
+          publishedAt: date,
+          retrievedAt: "2026-08-02T00:00:00.000Z",
+          sourceHash: "official-openapi-vote"
+        }
+      ],
+      summaries: [
+        {
+          ...source.summary,
+          officialTally: {
+            ...source.summary.officialTally,
+            presentCount: 2,
+            yesCount: 2
+          }
+        }
+      ],
+      voteMemberListPayloads: [
+        {
+          entry: source.entry,
+          html
+        }
+      ],
+      assemblyNo: 22,
+      snapshotId: "official-two-duplicate-names-fixture",
+      snapshotRetrievedAt: "2026-08-02T00:00:00.000Z",
+      tenureIndex
+    });
+
+    expect(
+      merged.voteFacts
+        .filter((fact) => fact.rollCallId === rollCallId)
+        .map((fact) => [fact.memberId, fact.voteCode])
+        .sort()
+    ).toEqual([
+      [seniorPark.memberId, "yes"],
+      [newPark.memberId, "yes"]
+    ]);
+  });
+
+  it("still fails closed when same-name LIKMS voters lack official disambiguation", () => {
+    const source = buildVoteSource({
+      billId: "PRC_UNRESOLVED_DUPLICATE_NAME",
+      billNo: "2219998",
+      date: "2026-07-23",
+      voteCode: "yes",
+      member: newPark
+    });
+
+    expect(() =>
+      mergeOfficialVoteFacts({
+        members: [seniorPark, newPark],
+        rollCalls: [],
+        voteFacts: [],
+        summaries: [source.summary],
+        voteMemberListPayloads: [
+          {
+            entry: source.entry,
+            html: source.html.replace(
+              newPark.officialProfileUrl ?? "",
+              "javascript:void(0);"
+            )
+          }
+        ],
+        assemblyNo: 22,
+        snapshotId: "official-unresolved-duplicate-name-fixture",
+        snapshotRetrievedAt: "2026-08-02T00:00:00.000Z",
+        tenureIndex
+      })
+    ).toThrow(/member name is ambiguous/);
+  });
+
+  it("fails closed when official exclusions consume every same-name candidate", () => {
+    const date = "2026-07-23";
+    const source = buildVoteSource({
+      billId: "PRC_CONFLICTING_DUPLICATE_NAME",
+      billNo: "2219996",
+      date,
+      voteCode: "yes",
+      member: newPark
+    });
+    const rollCallId = `${buildMeetingId({
+      assemblyNo: 22,
+      sessionNo: 0,
+      meetingNo: 0,
+      meetingDate: date
+    })}:${source.summary.billId}`;
+    const absentFacts = [seniorPark, newPark].map((member) => ({
+      rollCallId,
+      memberId: member.memberId,
+      memberName: member.name,
+      party: member.party,
+      voteCode: "absent" as const,
+      publishedAt: date,
+      retrievedAt: "2026-08-02T00:00:00.000Z",
+      sourceHash: `official-openapi-absence-${member.memberId}`
+    }));
+
+    expect(() =>
+      mergeOfficialVoteFacts({
+        members: [seniorPark, newPark],
+        rollCalls: [],
+        voteFacts: absentFacts,
+        summaries: [source.summary],
+        voteMemberListPayloads: [
+          {
+            entry: source.entry,
+            html: source.html.replace(
+              newPark.officialProfileUrl ?? "",
+              "javascript:void(0);"
+            )
+          }
+        ],
+        assemblyNo: 22,
+        snapshotId: "official-conflicting-duplicate-name-fixture",
+        snapshotRetrievedAt: "2026-08-02T00:00:00.000Z",
+        tenureIndex
+      })
+    ).toThrow(/conflicts with already identified rows/);
   });
 });
 


### PR DESCRIPTION
## Summary
- resolve same-name official vote rows only when OpenAPI identities and LIKMS profile rows leave one unique current member
- fail closed on contradictory or exhausted same-name mappings
- validate official minutes viewer meeting ID, date, response URL, and attendance counts before storage or cache reuse
- fall back only to the official National Assembly minutes search API when the viewer payload is invalid
- reject duplicate or incomplete attendance lists

## Verification
- npm test -- --run (318 tests)
- npm run typecheck
- npm run lint
- git diff --check