### PR TITLE
Prefer official plenary attendance files

### DIFF
--- a/packages/ingest/src/official-attendance.ts
+++ b/packages/ingest/src/official-attendance.ts
@@ -254,7 +254,23 @@ export async function loadOfficialMinutesAttendanceMeetings(args: {
     if (isPlenary && isPlenaryOpeningCeremonyHtml(html)) {
       continue;
     }
-    const attendance = parseOfficialMinutesAttendanceHtml(html);
+    let attendance: ReturnType<typeof parseOfficialMinutesAttendanceHtml>;
+    try {
+      attendance = parseOfficialMinutesAttendanceHtml(html);
+    } catch (error) {
+      if (
+        !isPlenary ||
+        !(error instanceof Error) ||
+        !error.message.includes("attendance list count mismatch")
+      ) {
+        throw error;
+      }
+      attendance = {
+        presentNames: [],
+        leaveNames: [],
+        tripNames: []
+      };
+    }
 
     const committeeName = isPlenary
       ? null
@@ -358,20 +374,13 @@ export function supplementOfficialMinutesAttendance(args: {
   });
 
   const supplementedMinutes = args.minutesMeetings.flatMap((meeting) => {
-    if (hasPublishedAttendance(meeting)) {
-      return [meeting];
+    if (meeting.meetingType === "plenary") {
+      const supplements = fileMeetingsByDate.get(meeting.meetingDate) ?? [];
+      if (supplements.length > 0) {
+        return [fromAttendanceFile(supplements[0]!, meeting)];
+      }
     }
-    if (meeting.meetingType !== "plenary") {
-      return [];
-    }
-
-    const supplements = fileMeetingsByDate.get(meeting.meetingDate) ?? [];
-    if (supplements.length === 0) {
-      return [];
-    }
-    const supplement = supplements[0]!;
-
-    return [fromAttendanceFile(supplement, meeting)];
+    return hasPublishedAttendance(meeting) ? [meeting] : [];
   });
 
   const fileOnlyMeetings = args.plenaryFileMeetings

--- a/packages/ingest/src/scripts/mirror-documents.ts
+++ b/packages/ingest/src/scripts/mirror-documents.ts
@@ -1875,6 +1875,7 @@ function requiresOfficialMinutesAttendanceVerification(args: {
   }
   return (
     isOfficialAttendanceRelevantMinutesTitle(args.title) &&
+    !args.title.includes("국회본회의 회의록") &&
     readString(args.sourceMetadata?.meetingSubtitle) !== "개회식"
   );
 }

--- a/tests/ingest/document-mirror.test.ts
+++ b/tests/ingest/document-mirror.test.ts
@@ -335,6 +335,21 @@ describe("document mirror helpers", () => {
           }
         })
       ).resolves.toBe(true);
+      await expect(
+        mirroredDocumentMatchesMetadata(root, {
+          latestRelativePath: relativePath,
+          currentBytes: body.byteLength,
+          currentContentSha256: sha256Buffer(body),
+          sourceUrl:
+            "https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?id=57073&type=view",
+          publishedDate: "2026-07-30",
+          title: "제22대 제437회 국회본회의 회의록",
+          sourceMetadata: {
+            minutesId: "57073",
+            classCode: "1"
+          }
+        })
+      ).resolves.toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/ingest/official-sources.test.ts
+++ b/tests/ingest/official-sources.test.ts
@@ -178,6 +178,10 @@ describe("official committee and minutes attendance sources", () => {
       '<p><strong>◯출석 의원 (1인)</strong></p><div class="con"><span class="name">김 아라</span></div><p><strong>◯청가 의원 (1인)</strong></p><div class="con"><span class="name">이 보라</span></div>'
     );
     await writeFile(
+      join(minutesDir, "plenary-incomplete.html"),
+      '<p><strong>◯출석 의원 (2인)</strong></p><div class="con"><span class="name">김 아라</span></div>'
+    );
+    await writeFile(
       join(minutesDir, "committee.html"),
       '<p><strong>◯출석 위원 (1인)</strong></p><div class="con"><span class="name">박 초록</span></div><p><strong>◯출장 위원 (1인)</strong></p><div class="con"><span class="name">최 파랑</span></div>'
     );
@@ -212,6 +216,17 @@ describe("official committee and minutes attendance sources", () => {
             currentContentSha256: "plenary-hash"
           },
           {
+            documentId: "plenary-incomplete",
+            sourceId: "assembly-minutes",
+            sourceUrl:
+              "https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?key=plenary-incomplete",
+            title: "제22대 제1회 국회본회의 회의록",
+            publishedDate: "2026-07-31",
+            latestRelativePath: "raw/minutes/plenary-incomplete.html",
+            lastMirroredAt: "2026-08-02T01:00:00.000Z",
+            currentContentSha256: "plenary-incomplete-hash"
+          },
+          {
             documentId: "plenary-ceremony",
             sourceId: "assembly-minutes",
             sourceUrl:
@@ -228,6 +243,15 @@ describe("official committee and minutes attendance sources", () => {
     await expect(
       loadOfficialMinutesAttendanceMeetings({ dataRepoDir, assemblyNo: 22 })
     ).resolves.toEqual([
+      expect.objectContaining({
+        documentId: "plenary-incomplete",
+        meetingType: "plenary",
+        committeeName: null,
+        presentNames: [],
+        leaveNames: [],
+        tripNames: [],
+        sourceHash: "plenary-incomplete-hash"
+      }),
       expect.objectContaining({
         documentId: "plenary-1",
         meetingType: "plenary",
@@ -249,13 +273,13 @@ describe("official committee and minutes attendance sources", () => {
     ]);
   });
 
-  it("uses official XLSX rows for missing minutes attendance and omitted plenary dates", () => {
+  it("prefers official XLSX rows over minutes and adds omitted plenary dates", () => {
     const minutesMeeting = {
       documentId: "minutes-1",
       meetingDate: "2026-04-17",
       meetingType: "plenary" as const,
       committeeName: null,
-      presentNames: [],
+      presentNames: ["회의록 값"],
       absentNames: [],
       leaveNames: [],
       tripNames: [],


### PR DESCRIPTION
## Summary
- use the National Assembly plenary attendance XLSX as the authoritative source whenever it exists, even when minutes also contain an attendance section
- tolerate incomplete plenary minutes attendance appendices so the dedicated official file can supply explicit present, absent, leave, and trip statuses
- keep main standing-committee minutes attendance fail-closed
- stop requiring embedded plenary attendance during mirror validation while preserving meeting ID and date validation

## Verification
- npm test -- --run (319 tests)
- npm run typecheck
- npm run lint
- npm run format:check
- git diff --check