### PR TITLE
Repair indexed official Assembly minutes

### DIFF
--- a/.github/workflows/mirror-documents.yml
+++ b/.github/workflows/mirror-documents.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: false
         type: boolean
+      retry_existing_only:
+        description: Revalidate and repair only indexed official Assembly minutes
+        required: false
+        default: false
+        type: boolean
       include_appendices:
         description: Deprecated; official minutes catalogs do not publish appendix files
         required: false
@@ -79,10 +84,19 @@ jobs:
       MIRROR_BACKFILL_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_BACKFILL_WINDOWS_PER_RUN || '1' }}
       MIRROR_CATCHUP_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_CATCHUP_WINDOWS_PER_RUN || '2' }}
       MIRROR_SKIP_RECENT: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_recent || 'false' }}
+      MIRROR_RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}
       MIRROR_INCLUDE_APPENDICES: "false"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Validate indexed repair configuration
+        if: env.MIRROR_RETRY_EXISTING_ONLY == 'true'
+        run: |
+          if [ -z "${DATA_REPO}" ] || [ -z "${DATA_REPO_PAT}" ]; then
+            echo "Indexed minutes repair requires DATA_REPO and DATA_REPO_PAT." >&2
+            exit 1
+          fi
 
       - name: Setup Node, install dependencies, and build shared workspaces
         uses: ./.github/actions/setup-node-workspaces
@@ -151,6 +165,18 @@ jobs:
           echo "pending_backfill=$(jq -r '.pendingBackfill // false' "${STATE_FILE}")" >> "${GITHUB_OUTPUT}"
           echo "backfill_advanced=$(jq -r '.backfillAdvanced // false' "${STATE_FILE}")" >> "${GITHUB_OUTPUT}"
 
+      - name: Validate indexed minutes repair
+        if: env.MIRROR_RETRY_EXISTING_ONLY == 'true'
+        run: |
+          jq -e '
+            .retryExistingOnly == true and
+            (.existingRetryCandidates // 0) > 0 and
+            .existingRetryChecked == .existingRetryCandidates and
+            (.existingRetryInvalid // -1) == 0 and
+            .pendingExistingRetry == false and
+            (.downloadFailures // 0) == 0
+          ' published-data/manifests/document_mirror_state.json
+
       - name: Start minutes summaries
         if: env.DATA_REPO != '' && env.DATA_REPO_PAT != ''
         env:
@@ -162,6 +188,7 @@ jobs:
 
       - name: Continue pending minutes backfill
         if: >-
+          env.MIRROR_RETRY_EXISTING_ONLY != 'true' &&
           steps.mirror-progress.outputs.pending_backfill == 'true' &&
           steps.mirror-progress.outputs.backfill_advanced == 'true'
         env:
@@ -172,6 +199,7 @@ jobs:
             -f backfill_windows="${MIRROR_CATCHUP_WINDOWS_PER_RUN}" \
             -f max_downloads="${MIRROR_MAX_DOWNLOADS}" \
             -f skip_recent=true \
+            -f retry_existing_only="${MIRROR_RETRY_EXISTING_ONLY}" \
             -f retry_attempt="0"
 
   retry-failed-mirror:
@@ -193,6 +221,7 @@ jobs:
           BACKFILL_WINDOWS: ${{ inputs.backfill_windows || '1' }}
           MAX_DOWNLOADS: ${{ inputs.max_downloads || vars.MIRROR_MAX_DOWNLOADS || '500' }}
           SKIP_RECENT: ${{ inputs.skip_recent || 'false' }}
+          RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}
         run: |
           if ! [[ "${CURRENT_RETRY_ATTEMPT}" =~ ^[0-9]+$ ]]; then
             echo "Invalid retry attempt: ${CURRENT_RETRY_ATTEMPT}" >&2
@@ -211,6 +240,7 @@ jobs:
             -f "backfill_windows=${BACKFILL_WINDOWS}"
             -f "max_downloads=${MAX_DOWNLOADS}"
             -f "skip_recent=${SKIP_RECENT}"
+            -f "retry_existing_only=${RETRY_EXISTING_ONLY}"
             -f "retry_attempt=${NEXT_RETRY_ATTEMPT}"
           )
           if [ -n "${BACKFILL_START_DATE}" ]; then

--- a/packages/ingest/src/document-mirror.ts
+++ b/packages/ingest/src/document-mirror.ts
@@ -99,6 +99,11 @@ export type DocumentMirrorState = {
   sourceSnapshotSha256?: string;
   sourceSnapshotCount?: number;
   skippedBySourceSnapshot?: boolean;
+  retryExistingOnly?: boolean;
+  existingRetryCandidates?: number;
+  existingRetryChecked?: number;
+  existingRetryInvalid?: number;
+  pendingExistingRetry?: boolean;
 };
 
 export type DocumentPathSet = {

--- a/packages/ingest/src/official-attendance.ts
+++ b/packages/ingest/src/official-attendance.ts
@@ -109,7 +109,10 @@ export function parseCommitteeCareerSheetJson(
   });
 }
 
-function readSectionNames(html: string, sectionPattern: RegExp): string[] {
+function readAttendanceSection(
+  html: string,
+  sectionPattern: RegExp
+): { names: string[]; parsedCount: number; publishedCount: number | null } {
   const $ = load(html);
   const heading = $("strong")
     .filter((_, element) =>
@@ -117,7 +120,7 @@ function readSectionNames(html: string, sectionPattern: RegExp): string[] {
     )
     .first();
   if (heading.length === 0) {
-    return [];
+    return { names: [], parsedCount: 0, publishedCount: null };
   }
 
   const names = heading
@@ -131,17 +134,30 @@ function readSectionNames(html: string, sectionPattern: RegExp): string[] {
     heading.text().match(/\((\d+)인\)/)?.[1] ?? "",
     10
   );
-  const uniqueNames = [...new Set(names)];
+  return {
+    names: [...new Set(names)],
+    parsedCount: names.length,
+    publishedCount: Number.isFinite(publishedCount) ? publishedCount : null
+  };
+}
+
+function assertAttendanceSectionCount(
+  section: {
+    names: string[];
+    parsedCount: number;
+    publishedCount: number | null;
+  },
+  acceptedCount = section.names.length
+): void {
   if (
-    Number.isFinite(publishedCount) &&
-    (publishedCount !== names.length || publishedCount !== uniqueNames.length)
+    section.parsedCount !== section.names.length ||
+    (section.publishedCount !== null &&
+      section.publishedCount !== acceptedCount)
   ) {
     throw new Error(
-      `Official minutes attendance list count mismatch: heading ${publishedCount}, parsed ${names.length}, unique ${uniqueNames.length}.`
+      `Official minutes attendance list count mismatch: heading ${section.publishedCount}, parsed ${section.parsedCount}, unique ${section.names.length}.`
     );
   }
-
-  return uniqueNames;
 }
 
 export function parseOfficialMinutesAttendanceHtml(html: string): {
@@ -149,10 +165,33 @@ export function parseOfficialMinutesAttendanceHtml(html: string): {
   leaveNames: string[];
   tripNames: string[];
 } {
+  const present = readAttendanceSection(html, /^◯출석 (?:의원|위원)\s*\(/);
+  const leave = readAttendanceSection(html, /^◯청가 (?:의원|위원)\s*\(/);
+  const trip = readAttendanceSection(html, /^◯출장 (?:의원|위원)\s*\(/);
+  assertAttendanceSectionCount(leave);
+  assertAttendanceSectionCount(trip);
+  const presentNames = new Set(present.names);
+  const normalizedLeaveNames = leave.names.filter(
+    (name) => !presentNames.has(name)
+  );
+  const leaveNames = new Set(normalizedLeaveNames);
+  const normalizedTripNames = trip.names.filter(
+    (name) => !presentNames.has(name) && !leaveNames.has(name)
+  );
+  const normalizedAttendanceCount =
+    present.names.length +
+    normalizedLeaveNames.length +
+    normalizedTripNames.length;
+  const publishedPresentCount =
+    present.publishedCount === normalizedAttendanceCount
+      ? normalizedAttendanceCount
+      : present.names.length;
+  assertAttendanceSectionCount(present, publishedPresentCount);
+
   return {
-    presentNames: readSectionNames(html, /^◯출석 (?:의원|위원)\s*\(/),
-    leaveNames: readSectionNames(html, /^◯청가 (?:의원|위원)\s*\(/),
-    tripNames: readSectionNames(html, /^◯출장 (?:의원|위원)\s*\(/)
+    presentNames: present.names,
+    leaveNames: normalizedLeaveNames,
+    tripNames: normalizedTripNames
   };
 }
 
@@ -161,14 +200,28 @@ function isMainStandingCommittee(title: string): boolean {
     /위원회 회의록$/.test(title) &&
     !title.includes("(") &&
     !title.includes("소위원회") &&
+    !title.includes("안건조정위원회") &&
     !title.includes("특별위원회")
   );
 }
 
-export function isOfficialAttendanceRelevantMinutesTitle(
-  title: string
+function isSubcommitteeMeetingSubtitle(
+  value: string | null | undefined
 ): boolean {
-  return title.includes("국회본회의 회의록") || isMainStandingCommittee(title);
+  return /(?:소위원회|안건조정위원회)(?:회의록)?$/.test(
+    normalizeComparableText(value)
+  );
+}
+
+export function isOfficialAttendanceRelevantMinutesTitle(
+  title: string,
+  meetingSubtitle?: string | null
+): boolean {
+  return (
+    title.includes("국회본회의 회의록") ||
+    (isMainStandingCommittee(title) &&
+      !isSubcommitteeMeetingSubtitle(meetingSubtitle))
+  );
 }
 
 function assertOfficialMinutesUrl(sourceUrl: string): void {
@@ -227,7 +280,8 @@ export async function loadOfficialMinutesAttendanceMeetings(args: {
       continue;
     }
 
-    if (isPlenary && item.metadataRelativePath) {
+    let meetingSubtitle: string | null | undefined;
+    if (item.metadataRelativePath) {
       try {
         const metadata = JSON.parse(
           await readFile(
@@ -235,15 +289,19 @@ export async function loadOfficialMinutesAttendanceMeetings(args: {
             "utf8"
           )
         ) as MirroredDocumentMetadata;
+        meetingSubtitle = metadata.sourceMetadata?.meetingSubtitle;
         if (
-          normalizeComparableText(metadata.sourceMetadata?.meetingSubtitle) ===
-          "개회식"
+          isPlenary &&
+          normalizeComparableText(meetingSubtitle) === "개회식"
         ) {
           continue;
         }
       } catch {
         // Older mirrors may not include metadata. The HTML remains authoritative.
       }
+    }
+    if (!isOfficialAttendanceRelevantMinutesTitle(title, meetingSubtitle)) {
+      continue;
     }
 
     assertOfficialMinutesUrl(item.sourceUrl);

--- a/packages/ingest/src/scripts/mirror-documents.ts
+++ b/packages/ingest/src/scripts/mirror-documents.ts
@@ -94,6 +94,7 @@ type MirrorConfig = {
   backfillCursorOverride?: string;
   backfillWindowsPerRun: number;
   skipRecent: boolean;
+  retryExistingOnly: boolean;
   includeAppendices: boolean;
   serviceInfId?: string;
   serviceInfSeq: number;
@@ -216,6 +217,7 @@ const assemblyMinuteRecordKeys = [
   "record6",
   "record7"
 ] as const;
+const assemblyMinuteClassCodes = ["1", "2", "3", "4", "5", "6", "7"] as const;
 
 const assemblyAppendixRecordKeys = ["record_app", "record_app_bo"] as const;
 
@@ -257,6 +259,13 @@ export function resolveMirrorRecentDays(
     : configuredDays;
 }
 
+export function resolveMirrorDownloadConcurrency(
+  mode: MirrorMode,
+  configuredConcurrency: number
+): number {
+  return mode === "assembly_minutes_catalog" ? 1 : configuredConcurrency;
+}
+
 export function resolveMirrorDataRepoDir(
   repositoryRoot: string,
   configuredPath: string | undefined
@@ -284,7 +293,7 @@ function loadConfig(): MirrorConfig {
       : "generic");
   const configuredRecentDays = readPositiveInteger("MIRROR_RECENT_DAYS", 3);
 
-  return {
+  const config: MirrorConfig = {
     mode,
     sourceId:
       process.env.MIRROR_SOURCE_ID?.trim() || "assembly-public-documents",
@@ -305,7 +314,10 @@ function loadConfig(): MirrorConfig {
       ".page_nav a.next:not([disabled])",
     maxPages: readPositiveInteger("MIRROR_MAX_PAGES", 25),
     maxDownloads: readPositiveInteger("MIRROR_MAX_DOWNLOADS", 500),
-    downloadConcurrency: readPositiveInteger("MIRROR_DOWNLOAD_CONCURRENCY", 4),
+    downloadConcurrency: resolveMirrorDownloadConcurrency(
+      mode,
+      readPositiveInteger("MIRROR_DOWNLOAD_CONCURRENCY", 4)
+    ),
     pageSize: readPositiveInteger("MIRROR_PAGE_SIZE", 100),
     pageDelayMs: readPositiveInteger("MIRROR_PAGE_DELAY_MS", 1000),
     timeoutMs: readPositiveInteger("MIRROR_TIMEOUT_MS", 20_000),
@@ -338,10 +350,24 @@ function loadConfig(): MirrorConfig {
       1
     ),
     skipRecent: readBooleanEnv("MIRROR_SKIP_RECENT", false),
+    retryExistingOnly: readBooleanEnv("MIRROR_RETRY_EXISTING_ONLY", false),
     includeAppendices: readBooleanEnv("MIRROR_INCLUDE_APPENDICES", true),
     serviceInfId,
     serviceInfSeq: readPositiveInteger("MIRROR_SERVICE_INF_SEQ", 1)
   };
+
+  if (config.retryExistingOnly && config.mode !== "assembly_minutes_catalog") {
+    throw new Error(
+      "MIRROR_RETRY_EXISTING_ONLY is supported only in assembly_minutes_catalog mode."
+    );
+  }
+  if (config.retryExistingOnly && config.backfillCursorOverride) {
+    throw new Error(
+      "MIRROR_BACKFILL_CURSOR_OVERRIDE cannot be used with MIRROR_RETRY_EXISTING_ONLY."
+    );
+  }
+
+  return config;
 }
 
 async function locatorText(locator: Locator): Promise<string | undefined> {
@@ -1109,21 +1135,24 @@ export function buildAssemblyMinutesCatalogParams(args: {
 
 export function buildAssemblyMinutesSearchFallbackParams(args: {
   meetingDate: string;
-  classCode: string;
+  classCode?: string;
   rows?: number;
 }): URLSearchParams {
-  if (!/^[1-7]$/.test(args.classCode)) {
+  if (args.classCode && !/^[1-7]$/.test(args.classCode)) {
     throw new Error(
       `Official Assembly minutes search fallback received invalid class code ${args.classCode}.`
     );
   }
 
+  const classCodes = args.classCode
+    ? [args.classCode]
+    : [...assemblyMinuteClassCodes];
   const compactMeetingDate = compactDate(args.meetingDate);
   return new URLSearchParams({
     startDate: compactMeetingDate,
     endDate: compactMeetingDate,
-    collection: `record${args.classCode}`,
-    CLASS_CD: args.classCode,
+    collection: classCodes.map((classCode) => `record${classCode}`).join(","),
+    CLASS_CD: classCodes.join(","),
     query: "",
     SPK_NM: "",
     SPKSAME: "N",
@@ -1132,6 +1161,43 @@ export function buildAssemblyMinutesSearchFallbackParams(args: {
     startCount: "1",
     listCount: String(args.rows ?? 50_000)
   });
+}
+
+export function selectCompleteAssemblyMinutesSearchFallbackMeeting(args: {
+  response: AssemblySearchResponse;
+  minutesId: string;
+  meetingDate: string;
+  expectedClassCode?: string;
+}): { classCode: string; rows: AssemblySearchItem[] } {
+  assertAssemblySearchResponsesComplete([args.response], false);
+  const matchingClassCodes = assemblyMinuteClassCodes.filter((classCode) =>
+    args.response[`record${classCode}`]?.resultList?.some(
+      (row) => readString(row.MNTS_ID) === args.minutesId
+    )
+  );
+  if (matchingClassCodes.length !== 1) {
+    throw new Error(
+      `Official Assembly minutes search fallback resolved ${matchingClassCodes.length} classes for ${args.minutesId}.`
+    );
+  }
+  const classCode = matchingClassCodes[0]!;
+  if (args.expectedClassCode && classCode !== args.expectedClassCode) {
+    throw new Error(
+      `Official Assembly minutes search fallback class mismatch for ${args.minutesId}: expected ${args.expectedClassCode}, received ${classCode}.`
+    );
+  }
+  const recordKey =
+    `record${classCode}` as `record${1 | 2 | 3 | 4 | 5 | 6 | 7}`;
+  return {
+    classCode,
+    rows: selectCompleteAssemblyMinutesSearchFallbackRows({
+      response: args.response,
+      recordKey,
+      minutesId: args.minutesId,
+      meetingDate: args.meetingDate,
+      classCode
+    })
+  };
 }
 
 export function selectCompleteAssemblyMinutesSearchFallbackRows(args: {
@@ -1689,6 +1755,81 @@ async function collectAssemblyMinutesCatalogCandidates(
   };
 }
 
+export function buildExistingAssemblyMinutesRetryCollection(args: {
+  existingIndex: MirroredDocumentIndex;
+  existingMetadataByDocumentId: Map<string, MirroredDocumentMetadata>;
+  existingState: DocumentMirrorState | null;
+  sourceId: string;
+}): CandidateCollectionResult {
+  if (args.existingIndex.sourceId !== args.sourceId) {
+    throw new Error(
+      `Existing document index source ${args.existingIndex.sourceId} does not match ${args.sourceId}.`
+    );
+  }
+  if (args.existingState && args.existingState.sourceId !== args.sourceId) {
+    throw new Error(
+      `Existing mirror state source ${args.existingState.sourceId} does not match ${args.sourceId}.`
+    );
+  }
+  for (const item of args.existingIndex.items) {
+    if (!args.existingMetadataByDocumentId.has(item.documentId)) {
+      throw new Error(
+        `Indexed document metadata is missing for ${item.documentId}.`
+      );
+    }
+  }
+
+  const officialItems = args.existingIndex.items.filter((item) =>
+    isOfficialAssemblyMinutesViewerUrl(item.sourceUrl)
+  );
+  if (officialItems.length === 0) {
+    throw new Error(
+      "Existing-only retry requires at least one indexed official Assembly minutes document."
+    );
+  }
+
+  const candidates = officialItems.map((item) => {
+    const metadata = args.existingMetadataByDocumentId.get(item.documentId);
+    if (!metadata) {
+      throw new Error(
+        `Indexed official Assembly minutes metadata is missing for ${item.documentId}.`
+      );
+    }
+    if (
+      metadata.sourceId !== args.sourceId ||
+      metadata.sourceUrl !== item.sourceUrl ||
+      metadata.publishedDate !== item.publishedDate ||
+      metadata.title !== item.title
+    ) {
+      throw new Error(
+        `Indexed official Assembly minutes metadata conflicts with ${item.documentId}.`
+      );
+    }
+
+    return {
+      documentId: metadata.documentId,
+      title: metadata.title,
+      sourceUrl: metadata.sourceUrl,
+      downloadUrl: metadata.downloadUrl,
+      publishedDate: metadata.publishedDate,
+      discoveredFromUrl: metadata.discoveredFromUrl,
+      sourceMetadata: metadata.sourceMetadata
+    };
+  });
+
+  return {
+    candidates,
+    pagesVisited: 0,
+    discoveredCandidates: candidates.length,
+    recentWindowStartDate: args.existingState?.recentWindowStartDate,
+    recentWindowEndDate: args.existingState?.recentWindowEndDate,
+    nextBackfillCursorDate: args.existingState?.nextBackfillCursorDate,
+    sourceSnapshotSha256: args.existingState?.sourceSnapshotSha256,
+    sourceSnapshotCount: args.existingState?.sourceSnapshotCount,
+    sourceSnapshotUnchanged: false
+  };
+}
+
 async function postAssemblyFileServiceSearch(
   api: APIRequestContext,
   config: MirrorConfig
@@ -1874,7 +2015,10 @@ function requiresOfficialMinutesAttendanceVerification(args: {
     return true;
   }
   return (
-    isOfficialAttendanceRelevantMinutesTitle(args.title) &&
+    isOfficialAttendanceRelevantMinutesTitle(
+      args.title,
+      readString(args.sourceMetadata?.meetingSubtitle)
+    ) &&
     !args.title.includes("국회본회의 회의록") &&
     readString(args.sourceMetadata?.meetingSubtitle) !== "개회식"
   );
@@ -1930,7 +2074,15 @@ export function assertAssemblyMinutesViewerPayloadMatchesCandidate(args: {
     );
   }
 
-  if (args.requireAttendance ?? true) {
+  const isEmptyTemporaryMinutes =
+    /<p[^>]*class=["'][^"']*\btmp\b[^"']*["'][^>]*>\s*\(임시회의록\)\s*<\/p>/i.test(
+      args.html
+    ) &&
+    /<div[^>]*class=["'][^"']*\bminutes_body\b[^"']*["'][^>]*>\s*<\/div>/i.test(
+      args.html
+    ) &&
+    !/◯출석\s*(?:의원|위원)\s*\(/.test(args.html);
+  if ((args.requireAttendance ?? true) && !isEmptyTemporaryMinutes) {
     assertOfficialMinutesAttendanceIsComplete(args.html);
   }
 }
@@ -2041,15 +2193,29 @@ async function downloadAssemblyMinutesSearchFallback(args: {
   const minutesId =
     readString(args.candidate.sourceMetadata?.minutesId) ??
     new URL(args.candidate.sourceUrl).searchParams.get("id");
-  const classCode = readString(args.candidate.sourceMetadata?.classCode);
+  const expectedClassCode = readString(
+    args.candidate.sourceMetadata?.classCode
+  );
   const meetingDate = args.candidate.publishedDate;
-  if (!minutesId || !classCode || !meetingDate) {
+  if (!minutesId || !meetingDate) {
     throw new Error(
-      "Official Assembly minutes search fallback requires a meeting id, class code, and date."
+      "Official Assembly minutes search fallback requires a meeting id and date."
     );
   }
 
   const searchUrl = `${officialAssemblyMinutesOrigin}/assembly/mnts/search/search.do`;
+  await retryFetch(
+    async () => {
+      await args.api.get(searchUrl, {
+        timeout: args.config.timeoutMs,
+        failOnStatusCode: true
+      });
+    },
+    {
+      retries: 2,
+      backoffMs: Math.max(500, args.config.pageDelayMs)
+    }
+  );
   const responsePayload = await retryFetch(
     async () => {
       const response = await args.api.post(searchUrl, {
@@ -2060,7 +2226,7 @@ async function downloadAssemblyMinutesSearchFallback(args: {
         },
         data: buildAssemblyMinutesSearchFallbackParams({
           meetingDate,
-          classCode
+          classCode: expectedClassCode
         }).toString(),
         timeout: args.config.timeoutMs,
         failOnStatusCode: true
@@ -2072,15 +2238,13 @@ async function downloadAssemblyMinutesSearchFallback(args: {
       backoffMs: Math.max(500, args.config.pageDelayMs)
     }
   );
-  const recordKey =
-    `record${classCode}` as `record${1 | 2 | 3 | 4 | 5 | 6 | 7}`;
-  const rows = selectCompleteAssemblyMinutesSearchFallbackRows({
-    response: responsePayload,
-    recordKey,
-    minutesId,
-    meetingDate,
-    classCode
-  });
+  const { classCode, rows } =
+    selectCompleteAssemblyMinutesSearchFallbackMeeting({
+      response: responsePayload,
+      minutesId,
+      meetingDate,
+      expectedClassCode
+    });
   const html = buildAssemblyMinutesSearchFallbackHtml({
     minutesId,
     meetingDate,
@@ -2099,7 +2263,8 @@ async function downloadAssemblyMinutesSearchFallback(args: {
     contentType: "text/html; charset=utf-8",
     sourceMetadata: {
       retrievalMethod: "official_minutes_search_api_fallback",
-      fallbackSourceUrl: searchUrl
+      fallbackSourceUrl: searchUrl,
+      classCode
     }
   };
 }
@@ -2165,9 +2330,17 @@ async function mirrorCandidate(
         }
       });
     } catch (fallbackError) {
+      const viewerMessage =
+        downloadError instanceof Error
+          ? downloadError.message
+          : String(downloadError);
+      const fallbackMessage =
+        fallbackError instanceof Error
+          ? fallbackError.message
+          : String(fallbackError);
       throw new AggregateError(
         [downloadError, fallbackError],
-        `Official Assembly minutes viewer and search fallback failed for ${candidate.documentId ?? candidate.sourceUrl}.`
+        `Official Assembly minutes viewer and search fallback failed for ${candidate.documentId ?? candidate.sourceUrl}. Viewer: ${viewerMessage} Fallback: ${fallbackMessage}`
       );
     }
   }
@@ -2445,6 +2618,7 @@ async function processWithConcurrency<T>(
 export function shouldReuseExistingBackfillDocument(args: {
   mode: MirrorMode;
   skipRecent: boolean;
+  retryExistingOnly?: boolean;
   workItemKind: "discovered" | "transcript-refresh";
   hasExistingMetadata: boolean;
   hasFreshTranscript: boolean;
@@ -2452,12 +2626,37 @@ export function shouldReuseExistingBackfillDocument(args: {
 }): boolean {
   return (
     args.mode === "assembly_minutes_catalog" &&
-    args.skipRecent &&
+    (args.skipRecent || args.retryExistingOnly === true) &&
     args.workItemKind === "discovered" &&
     args.hasExistingMetadata &&
     args.hasFreshTranscript &&
     args.rawMatchesMetadata
   );
+}
+
+export async function auditExistingAssemblyMinutesRetry(args: {
+  dataRepoDir: string;
+  candidates: MirrorCandidate[];
+  metadataByDocumentId: Map<string, MirroredDocumentMetadata>;
+}): Promise<{ checked: number; invalid: number }> {
+  let checked = 0;
+  let invalid = 0;
+
+  for (const candidate of args.candidates) {
+    const documentId = candidate.documentId;
+    const metadata = documentId
+      ? args.metadataByDocumentId.get(documentId)
+      : undefined;
+    checked += 1;
+    if (
+      !metadata ||
+      !(await mirroredDocumentMatchesMetadata(args.dataRepoDir, metadata))
+    ) {
+      invalid += 1;
+    }
+  }
+
+  return { checked, invalid };
 }
 
 export function shouldBlockBackfillCursorOnDownloadFailure(args: {
@@ -2581,8 +2780,14 @@ async function main(): Promise<void> {
     userAgent: config.userAgent
   });
 
-  const collectionResult =
-    config.mode === "assembly_minutes_search"
+  const collectionResult = config.retryExistingOnly
+    ? buildExistingAssemblyMinutesRetryCollection({
+        existingIndex,
+        existingMetadataByDocumentId: existingMetadata.byDocumentId,
+        existingState,
+        sourceId: config.sourceId
+      })
+    : config.mode === "assembly_minutes_search"
       ? await collectAssemblyCandidates(
           page!,
           api,
@@ -2606,8 +2811,9 @@ async function main(): Promise<void> {
             )
           : await collectGenericCandidates(page!, config);
   const transcriptRefreshCandidates =
-    config.mode === "assembly_minutes_search" ||
-    config.mode === "assembly_minutes_catalog"
+    !config.retryExistingOnly &&
+    (config.mode === "assembly_minutes_search" ||
+      config.mode === "assembly_minutes_catalog")
       ? buildTranscriptRefreshCandidates(existingMetadata.byDocumentId)
       : [];
   const staleTranscriptDocumentIds = new Set(
@@ -2655,7 +2861,10 @@ async function main(): Promise<void> {
       continue;
     }
 
-    if (!isPastDocumentDate(candidate.publishedDate, cutoffDate)) {
+    if (
+      !config.retryExistingOnly &&
+      !isPastDocumentDate(candidate.publishedDate, cutoffDate)
+    ) {
       skippedTodayOrFuture += 1;
       continue;
     }
@@ -2683,9 +2892,11 @@ async function main(): Promise<void> {
       shouldReuseExistingBackfillDocument({
         mode: config.mode,
         skipRecent: config.skipRecent,
+        retryExistingOnly: config.retryExistingOnly,
         workItemKind: workItem.kind,
         hasExistingMetadata: Boolean(existingCandidateMetadata),
         hasFreshTranscript:
+          config.retryExistingOnly ||
           !isAssemblyMinutesViewerUrl(candidate.sourceUrl) ||
           existingCandidateMetadata?.transcriptParserVersion ===
             ASSEMBLY_MINUTES_TRANSCRIPT_PARSER_VERSION,
@@ -2808,17 +3019,20 @@ async function main(): Promise<void> {
     ),
     retrievedAt
   );
-  const previousBackfillCursorDate =
-    config.backfillCursorOverride ??
-    existingState?.nextBackfillCursorDate ??
-    config.backfillStartDate;
-  const nextBackfillCursorDate = resolvePublishedBackfillCursor({
-    proposedCursor: collectionResult.nextBackfillCursorDate,
-    fallbackCursor: previousBackfillCursorDate,
-    skippedWithoutDate,
-    downloadFailures,
-    reachedDownloadLimit
-  });
+  const previousBackfillCursorDate = config.retryExistingOnly
+    ? (existingState?.nextBackfillCursorDate ?? config.backfillStartDate)
+    : (config.backfillCursorOverride ??
+      existingState?.nextBackfillCursorDate ??
+      config.backfillStartDate);
+  const nextBackfillCursorDate = config.retryExistingOnly
+    ? existingState?.nextBackfillCursorDate
+    : resolvePublishedBackfillCursor({
+        proposedCursor: collectionResult.nextBackfillCursorDate,
+        fallbackCursor: previousBackfillCursorDate,
+        skippedWithoutDate,
+        downloadFailures,
+        reachedDownloadLimit
+      });
   const latestDiscoveredDocumentDate =
     collectionResult.candidates
       .map((candidate) => candidate.publishedDate)
@@ -2834,6 +3048,19 @@ async function main(): Promise<void> {
     existingState?.recentWindowStartDate;
   const recentWindowEndDate =
     collectionResult.recentWindowEndDate ?? existingState?.recentWindowEndDate;
+  const existingRetryAudit = config.retryExistingOnly
+    ? await auditExistingAssemblyMinutesRetry({
+        dataRepoDir: config.dataRepoDir,
+        candidates: collectionResult.candidates,
+        metadataByDocumentId: updatedMetadataByDocumentId
+      })
+    : null;
+  const pendingExistingRetry = Boolean(
+    existingRetryAudit &&
+    (existingRetryAudit.invalid > 0 ||
+      downloadFailures > 0 ||
+      reachedDownloadLimit)
+  );
 
   const state: DocumentMirrorState = {
     sourceId: config.sourceId,
@@ -2858,17 +3085,26 @@ async function main(): Promise<void> {
       nextBackfillCursorDate,
       recentWindowStartDate
     }),
-    backfillAdvanced: Boolean(
-      nextBackfillCursorDate &&
-      nextBackfillCursorDate > previousBackfillCursorDate
-    ),
+    backfillAdvanced:
+      !config.retryExistingOnly &&
+      Boolean(
+        nextBackfillCursorDate &&
+        nextBackfillCursorDate > previousBackfillCursorDate
+      ),
     latestDiscoveredDocumentDate,
     latestMirroredDocumentDate: index.items[0]?.publishedDate ?? null,
     staleTranscriptsQueued: staleTranscriptDocumentIds.size,
     staleTranscriptsRefreshed,
     sourceSnapshotSha256: collectionResult.sourceSnapshotSha256,
     sourceSnapshotCount: collectionResult.sourceSnapshotCount,
-    skippedBySourceSnapshot: collectionResult.sourceSnapshotUnchanged ?? false
+    skippedBySourceSnapshot: collectionResult.sourceSnapshotUnchanged ?? false,
+    retryExistingOnly: config.retryExistingOnly,
+    existingRetryCandidates: existingRetryAudit
+      ? collectionResult.candidates.length
+      : undefined,
+    existingRetryChecked: existingRetryAudit?.checked,
+    existingRetryInvalid: existingRetryAudit?.invalid,
+    pendingExistingRetry: existingRetryAudit ? pendingExistingRetry : undefined
   };
 
   await writeJsonFile(indexFile, index);

--- a/tests/ingest/document-mirror.test.ts
+++ b/tests/ingest/document-mirror.test.ts
@@ -13,7 +13,8 @@ import {
   mergeDocumentIndex,
   normalizeDocumentDate,
   selectExistingMirroredMetadata,
-  slugifySegment
+  slugifySegment,
+  toIndexItem
 } from "../../packages/ingest/src/document-mirror.js";
 import {
   buildAssemblySearchWindows,
@@ -28,7 +29,9 @@ import {
   assertAssemblyMinutesSearchFallbackPayloadMatchesCandidate,
   assertAssemblyMinutesViewerPayloadMatchesCandidate,
   assertAssemblySearchResponsesComplete,
+  auditExistingAssemblyMinutesRetry,
   buildAssemblyFileServiceSourceSnapshot,
+  buildExistingAssemblyMinutesRetryCollection,
   buildAssemblyMinutesCatalogCandidate,
   buildAssemblyMinutesCatalogParams,
   buildAssemblyMinutesParams,
@@ -37,9 +40,11 @@ import {
   isAssemblyMinutesViewerUrl,
   mirroredDocumentMatchesMetadata,
   normalizeCompactAssemblyDate,
+  resolveMirrorDownloadConcurrency,
   resolveMirrorRecentDays,
   resolveMirrorDataRepoDir,
   responsePageCount,
+  selectCompleteAssemblyMinutesSearchFallbackMeeting,
   selectCompleteAssemblyMinutesSearchFallbackRows,
   shouldBlockBackfillCursorOnDownloadFailure,
   shouldReuseExistingBackfillDocument,
@@ -50,6 +55,8 @@ import { parseOfficialMinutesAttendanceHtml } from "../../packages/ingest/src/of
 import { parseAssemblyMinutesViewerHtml } from "../../packages/ingest/src/minutes-transcript.js";
 import { buildMinutesSummaryGroups } from "../../packages/ingest/src/minutes-summarization.js";
 import { sha256Buffer } from "../../packages/ingest/src/utils.js";
+
+import type { MirroredDocumentMetadata } from "../../packages/ingest/src/document-mirror.js";
 
 function buildViewerIntegrityFixture(args?: {
   minutesId?: string;
@@ -93,11 +100,59 @@ function buildViewerIntegrityFixture(args?: {
   `;
 }
 
+function buildRetryMetadata(args: {
+  documentId: string;
+  minutesId: string;
+  publishedDate: string;
+  latestRelativePath: string;
+  body: Buffer;
+  sourceUrl?: string;
+}): MirroredDocumentMetadata {
+  const sourceUrl =
+    args.sourceUrl ??
+    `https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?id=${args.minutesId}&type=view`;
+  return {
+    documentId: args.documentId,
+    sourceId: "assembly-minutes",
+    sourceUrl,
+    downloadUrl: sourceUrl,
+    title: "제22대 제437회 보건복지위원회 회의록",
+    publishedDate: args.publishedDate,
+    discoveredFromUrl:
+      "https://open.assembly.go.kr/portal/data/service/selectServicePage.do/OR137O001023MZ19321",
+    firstMirroredAt: "2026-08-01T00:00:00.000Z",
+    lastMirroredAt: "2026-08-01T00:00:00.000Z",
+    latestRelativePath: args.latestRelativePath,
+    metadataRelativePath: `${args.latestRelativePath}.metadata.json`,
+    currentContentSha256: sha256Buffer(args.body),
+    currentContentType: "text/html",
+    currentBytes: args.body.byteLength,
+    sourceMetadata: {
+      minutesId: args.minutesId,
+      committeeName: "보건복지위원회"
+    },
+    versions: [
+      {
+        retrievedAt: "2026-08-01T00:00:00.000Z",
+        relativePath: args.latestRelativePath,
+        contentSha256: sha256Buffer(args.body),
+        bytes: args.body.byteLength
+      }
+    ]
+  };
+}
+
 describe("document mirror helpers", () => {
   it("keeps the recent safety floor for both official minutes collectors", () => {
     expect(resolveMirrorRecentDays("assembly_minutes_search", 3, 30)).toBe(30);
     expect(resolveMirrorRecentDays("assembly_minutes_catalog", 3, 30)).toBe(30);
     expect(resolveMirrorRecentDays("assembly_file_service", 3, 30)).toBe(3);
+    expect(
+      resolveMirrorDownloadConcurrency("assembly_minutes_catalog", 4)
+    ).toBe(1);
+    expect(resolveMirrorDownloadConcurrency("assembly_file_service", 4)).toBe(
+      4
+    );
   });
 
   it("reuses successful official backfill documents while retrying gaps", () => {
@@ -161,6 +216,143 @@ describe("document mirror helpers", () => {
         rawMatchesMetadata: false
       })
     ).toBe(false);
+    expect(
+      shouldReuseExistingBackfillDocument({
+        mode: "assembly_minutes_catalog",
+        skipRecent: false,
+        retryExistingOnly: true,
+        workItemKind: "discovered",
+        hasExistingMetadata: true,
+        hasFreshTranscript: true,
+        rawMatchesMetadata: true
+      })
+    ).toBe(true);
+  });
+
+  it("builds an existing-only retry from every indexed official minutes document", () => {
+    const body = Buffer.from(
+      buildViewerIntegrityFixture({
+        minutesId: "57073",
+        meetingDate: "2026.07.30"
+      })
+    );
+    const official = buildRetryMetadata({
+      documentId: "assembly-minutes-minutes-57073",
+      minutesId: "57073",
+      publishedDate: "2026-07-30",
+      latestRelativePath: "raw/official/latest.html",
+      body
+    });
+    const appendix = buildRetryMetadata({
+      documentId: "assembly-minutes-appendix-1",
+      minutesId: "1",
+      publishedDate: "2026-07-30",
+      latestRelativePath: "raw/appendix/latest.html",
+      body,
+      sourceUrl:
+        "https://record.assembly.go.kr/assembly/mnts/apdix/apdixDownload.do?fileId=1"
+    });
+    const existingIndex = mergeDocumentIndex(
+      "assembly-minutes",
+      [toIndexItem(official), toIndexItem(appendix)],
+      "2026-08-01T00:00:00.000Z"
+    );
+    const collection = buildExistingAssemblyMinutesRetryCollection({
+      existingIndex,
+      existingMetadataByDocumentId: new Map([
+        [official.documentId, official],
+        [appendix.documentId, appendix]
+      ]),
+      existingState: null,
+      sourceId: "assembly-minutes"
+    });
+
+    expect(collection.candidates).toHaveLength(1);
+    expect(collection.candidates[0]?.documentId).toBe(official.documentId);
+    expect(collection.pagesVisited).toBe(0);
+    expect(collection.nextBackfillCursorDate).toBeUndefined();
+
+    expect(() =>
+      buildExistingAssemblyMinutesRetryCollection({
+        existingIndex,
+        existingMetadataByDocumentId: new Map([
+          [appendix.documentId, appendix]
+        ]),
+        existingState: null,
+        sourceId: "assembly-minutes"
+      })
+    ).toThrow(/metadata is missing/);
+    expect(() =>
+      buildExistingAssemblyMinutesRetryCollection({
+        existingIndex,
+        existingMetadataByDocumentId: new Map([
+          [official.documentId, official]
+        ]),
+        existingState: null,
+        sourceId: "assembly-minutes"
+      })
+    ).toThrow(/assembly-minutes-appendix-1/);
+  });
+
+  it("keeps the indexed retry pending until every official raw artifact is valid", async () => {
+    const root = await mkdtemp(join(tmpdir(), "existing-minutes-retry-"));
+    try {
+      const validBody = Buffer.from(
+        buildViewerIntegrityFixture({
+          minutesId: "57073",
+          meetingDate: "2026.07.30"
+        })
+      );
+      const invalidBody = Buffer.from(
+        buildViewerIntegrityFixture({
+          minutesId: "57073",
+          meetingDate: "2026.07.31"
+        })
+      );
+      const valid = buildRetryMetadata({
+        documentId: "assembly-minutes-minutes-57073",
+        minutesId: "57073",
+        publishedDate: "2026-07-30",
+        latestRelativePath: "raw/valid/latest.html",
+        body: validBody
+      });
+      const invalid = buildRetryMetadata({
+        documentId: "assembly-minutes-minutes-57074",
+        minutesId: "57074",
+        publishedDate: "2026-07-31",
+        latestRelativePath: "raw/invalid/latest.html",
+        body: invalidBody
+      });
+      await mkdir(join(root, "raw/valid"), { recursive: true });
+      await mkdir(join(root, "raw/invalid"), { recursive: true });
+      await writeFile(join(root, valid.latestRelativePath), validBody);
+      await writeFile(join(root, invalid.latestRelativePath), invalidBody);
+      const existingIndex = mergeDocumentIndex(
+        "assembly-minutes",
+        [toIndexItem(valid), toIndexItem(invalid)],
+        "2026-08-01T00:00:00.000Z"
+      );
+      const metadataByDocumentId = new Map([
+        [valid.documentId, valid],
+        [invalid.documentId, invalid]
+      ]);
+      const collection = buildExistingAssemblyMinutesRetryCollection({
+        existingIndex,
+        existingMetadataByDocumentId: metadataByDocumentId,
+        existingState: null,
+        sourceId: "assembly-minutes"
+      });
+
+      await expect(
+        auditExistingAssemblyMinutesRetry({
+          dataRepoDir: root,
+          candidates: collection.candidates,
+          metadataByDocumentId
+        })
+      ).resolves.toEqual({ checked: 2, invalid: 1 });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("reuses a mirrored document only when the raw file matches metadata", async () => {
@@ -211,6 +403,20 @@ describe("document mirror helpers", () => {
     ).not.toThrow();
     expect(() =>
       assertAssemblyMinutesViewerPayloadMatchesCandidate({
+        html: buildViewerIntegrityFixture({
+          publishedCount: 2,
+          names: ["이소희"]
+        }).replace(
+          "<script>",
+          '<p class="tmp">(임시회의록)</p><div class="minutes_body"></div><script>'
+        ),
+        sourceUrl,
+        expectedMinutesId: "57073",
+        expectedMeetingDate: "2026-07-30"
+      })
+    ).toThrow(/attendance list count mismatch/);
+    expect(() =>
+      assertAssemblyMinutesViewerPayloadMatchesCandidate({
         html: buildViewerIntegrityFixture({ minutesId: "57054" }),
         sourceUrl,
         expectedMinutesId: "57073",
@@ -259,6 +465,19 @@ describe("document mirror helpers", () => {
         expectedMeetingDate: "2026-07-30"
       })
     ).toThrow(/no verified attendance list/);
+    expect(() =>
+      assertAssemblyMinutesViewerPayloadMatchesCandidate({
+        html: buildViewerIntegrityFixture({
+          includeAttendance: false
+        }).replace(
+          "<script>",
+          '<p class="tmp">(임시회의록)</p><div class="minutes_body"></div><script>'
+        ),
+        sourceUrl,
+        expectedMinutesId: "57073",
+        expectedMeetingDate: "2026-07-30"
+      })
+    ).not.toThrow();
     expect(() =>
       assertAssemblyMinutesViewerPayloadMatchesCandidate({
         html: buildViewerIntegrityFixture({
@@ -1062,6 +1281,13 @@ describe("document mirror helpers", () => {
     expect(params.get("collection")).toBe("record2");
     expect(params.get("CLASS_CD")).toBe("2");
     expect(params.get("listCount")).toBe("50000");
+    const legacyParams = buildAssemblyMinutesSearchFallbackParams({
+      meetingDate: "2025-02-26"
+    });
+    expect(legacyParams.get("collection")).toBe(
+      "record1,record2,record3,record4,record5,record6,record7"
+    );
+    expect(legacyParams.get("CLASS_CD")).toBe("1,2,3,4,5,6,7");
 
     const rows = [
       {
@@ -1097,6 +1323,21 @@ describe("document mirror helpers", () => {
       minutesId: "52713",
       meetingDate: "2025-02-26",
       classCode: "2"
+    });
+    expect(
+      selectCompleteAssemblyMinutesSearchFallbackMeeting({
+        response: {
+          record2: {
+            totalCount: rows.length,
+            resultList: rows
+          }
+        },
+        minutesId: "52713",
+        meetingDate: "2025-02-26"
+      })
+    ).toEqual({
+      classCode: "2",
+      rows
     });
     const sourceUrl =
       "https://record.assembly.go.kr/assembly/mnts/search/search.do";

--- a/tests/ingest/minutes-incremental-workflow.test.ts
+++ b/tests/ingest/minutes-incremental-workflow.test.ts
@@ -27,6 +27,24 @@ describe("incremental minutes workflows", () => {
     );
     expect(workflow).toContain('MIRROR_TIMEOUT_MS: "60000"');
     expect(workflow).toContain('MIRROR_INCLUDE_APPENDICES: "false"');
+    expect(workflow).toContain("retry_existing_only:");
+    expect(workflow).toContain(
+      "MIRROR_RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}"
+    );
+    expect(workflow).toContain("Validate indexed minutes repair");
+    expect(workflow).toContain("Validate indexed repair configuration");
+    expect(workflow).toContain(
+      "Indexed minutes repair requires DATA_REPO and DATA_REPO_PAT."
+    );
+    expect(workflow).toContain(
+      '-f retry_existing_only="${MIRROR_RETRY_EXISTING_ONLY}"'
+    );
+    expect(workflow).toContain(
+      "RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}"
+    );
+    expect(workflow).toContain(
+      '-f "retry_existing_only=${RETRY_EXISTING_ONLY}"'
+    );
     expect(workflow).not.toContain(
       '-f include_appendices="${MIRROR_INCLUDE_APPENDICES}"'
     );

--- a/tests/ingest/official-sources.test.ts
+++ b/tests/ingest/official-sources.test.ts
@@ -13,6 +13,7 @@ import {
   resolveAssemblyApiConfig
 } from "../../packages/ingest/src/assembly-api.js";
 import {
+  isOfficialAttendanceRelevantMinutesTitle,
   parseCommitteeCareerSheetJson,
   loadOfficialMinutesAttendanceMeetings,
   parseOfficialMinutesAttendanceHtml,
@@ -150,6 +151,24 @@ describe("official committee and minutes attendance sources", () => {
   });
 
   it("parses official plenary and committee attendance statuses", () => {
+    expect(
+      isOfficialAttendanceRelevantMinutesTitle(
+        "제22대 제437회 법제사법위원회 안건조정위원회 회의록"
+      )
+    ).toBe(false);
+    expect(
+      isOfficialAttendanceRelevantMinutesTitle(
+        "제22대 제430회 법제사법위원회 회의록",
+        "법안심사제1소위원회"
+      )
+    ).toBe(false);
+    expect(
+      isOfficialAttendanceRelevantMinutesTitle(
+        "제22대 제430회 법제사법위원회 회의록",
+        "1. 법안심사제1소위원회 위원 선임의 건"
+      )
+    ).toBe(true);
+
     const attendance = parseOfficialMinutesAttendanceHtml(`
       <p><strong>◯출석 의원 (2인)</strong></p>
       <div class="con"><a href="/members/1"><span class="name">김 아라</span></a><a href="/members/2"><span class="name">이 보라</span></a></div>
@@ -163,6 +182,45 @@ describe("official committee and minutes attendance sources", () => {
       presentNames: ["김 아라", "이 보라"],
       leaveNames: ["박 초록"],
       tripNames: ["최 파랑"]
+    });
+
+    expect(
+      parseOfficialMinutesAttendanceHtml(`
+        <p><strong>◯출석 위원 (3인)</strong></p>
+        <div class="con"><span class="name">김 아라</span><span class="name">이 보라</span></div>
+        <p><strong>◯청가 위원 (1인)</strong></p>
+        <div class="con"><span class="name">박 초록</span></div>
+      `)
+    ).toEqual({
+      presentNames: ["김 아라", "이 보라"],
+      leaveNames: ["박 초록"],
+      tripNames: []
+    });
+
+    expect(
+      parseOfficialMinutesAttendanceHtml(`
+        <p><strong>◯출석 위원 (2인)</strong></p>
+        <div class="con"><span class="name">김 아라</span><span class="name">이 보라</span></div>
+        <p><strong>◯청가 위원 (2인)</strong></p>
+        <div class="con"><span class="name">이 보라</span><span class="name">박 초록</span></div>
+      `)
+    ).toEqual({
+      presentNames: ["김 아라", "이 보라"],
+      leaveNames: ["박 초록"],
+      tripNames: []
+    });
+
+    expect(
+      parseOfficialMinutesAttendanceHtml(`
+        <p><strong>◯출석 위원 (3인)</strong></p>
+        <div class="con"><span class="name">김 아라</span><span class="name">이 보라</span></div>
+        <p><strong>◯청가 위원 (2인)</strong></p>
+        <div class="con"><span class="name">이 보라</span><span class="name">박 초록</span></div>
+      `)
+    ).toEqual({
+      presentNames: ["김 아라", "이 보라"],
+      leaveNames: ["박 초록"],
+      tripNames: []
     });
   });
 
@@ -186,6 +244,18 @@ describe("official committee and minutes attendance sources", () => {
       '<p><strong>◯출석 위원 (1인)</strong></p><div class="con"><span class="name">박 초록</span></div><p><strong>◯출장 위원 (1인)</strong></p><div class="con"><span class="name">최 파랑</span></div>'
     );
     await writeFile(
+      join(minutesDir, "subcommittee.html"),
+      '<p><strong>◯출석 위원 (1인)</strong></p><div class="con"><span class="name">제외 대상</span></div>'
+    );
+    await writeFile(
+      join(minutesDir, "subcommittee-metadata.json"),
+      JSON.stringify({
+        sourceMetadata: {
+          meetingSubtitle: "법안심사제1소위원회"
+        }
+      })
+    );
+    await writeFile(
       join(minutesDir, "ceremony.html"),
       '<div class="minutes_header"><div class="tit_wrap"><p class="num">개회식</p></div></div><p><strong>◯출석 의원 (1인)</strong></p><div class="con"><span class="name">제외 대상</span></div>'
     );
@@ -203,6 +273,17 @@ describe("official committee and minutes attendance sources", () => {
             publishedDate: "2026-08-02",
             latestRelativePath: "raw/minutes/committee.html",
             currentContentSha256: "committee-hash"
+          },
+          {
+            documentId: "subcommittee-1",
+            sourceId: "assembly-minutes",
+            sourceUrl:
+              "https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?key=subcommittee-1",
+            title: "제22대 제1회 법제사법위원회 회의록",
+            publishedDate: "2026-08-02",
+            latestRelativePath: "raw/minutes/subcommittee.html",
+            metadataRelativePath: "raw/minutes/subcommittee-metadata.json",
+            currentContentSha256: "subcommittee-hash"
           },
           {
             documentId: "plenary-1",


### PR DESCRIPTION
## Summary
- add an indexed-only recovery mode that revalidates and repairs every mirrored National Assembly minutes artifact without calling third-party services
- serialize official minutes downloads, bootstrap the official search session, and recover legacy records whose class code is absent
- preserve catalog backfill state independently from raw-artifact recovery and fail closed on missing metadata, incomplete repairs, or missing repository credentials
- handle official attendance edge cases: combined status counts, present/leave overlap, empty temporary minutes, and subcommittee exclusions

## Evidence
- `npm test`: 321 tests passed
- `npm run typecheck`: passed
- `npm run lint`: passed
- `npm run format:check`: passed
- live-data dry run: 1,793 indexed official minutes checked, 0 invalid, 0 download failures

## Source policy
Runtime recovery uses only `open.assembly.go.kr` and `record.assembly.go.kr`; no PeoplePower21/PSPD endpoint is added.