### PR TITLE
Handle official plenary attendance boundaries

### DIFF
--- a/packages/ingest/src/official-attendance.ts
+++ b/packages/ingest/src/official-attendance.ts
@@ -17,6 +17,11 @@ export type CommitteeCareerRecord = {
   endDate: string | null;
 };
 
+export type OfficialAttendanceMemberReference = {
+  name: string;
+  officialProfileUrl: string;
+};
+
 export type OfficialMinutesAttendanceMeeting = {
   documentId: string;
   meetingDate: string;
@@ -26,6 +31,9 @@ export type OfficialMinutesAttendanceMeeting = {
   absentNames?: string[];
   leaveNames: string[];
   tripNames: string[];
+  presentMemberReferences?: OfficialAttendanceMemberReference[];
+  leaveMemberReferences?: OfficialAttendanceMemberReference[];
+  tripMemberReferences?: OfficialAttendanceMemberReference[];
   requiresExplicitStatus?: boolean;
   sourceUrl: string;
   retrievedAt: string;
@@ -112,7 +120,12 @@ export function parseCommitteeCareerSheetJson(
 function readAttendanceSection(
   html: string,
   sectionPattern: RegExp
-): { names: string[]; parsedCount: number; publishedCount: number | null } {
+): {
+  names: string[];
+  memberReferences: OfficialAttendanceMemberReference[];
+  parsedCount: number;
+  publishedCount: number | null;
+} {
   const $ = load(html);
   const heading = $("strong")
     .filter((_, element) =>
@@ -120,22 +133,70 @@ function readAttendanceSection(
     )
     .first();
   if (heading.length === 0) {
-    return { names: [], parsedCount: 0, publishedCount: null };
+    return {
+      names: [],
+      memberReferences: [],
+      parsedCount: 0,
+      publishedCount: null
+    };
   }
 
-  const names = heading
+  const nameElements = heading
     .closest("p")
     .next(".con")
-    .find("a[href*='/members/'] .name, .name")
+    .find("a[href*='/members/'] .name, .name");
+  const names = nameElements
     .map((_, element) => normalizeComparableText($(element).text()))
     .get()
     .filter(Boolean);
+  const memberReferences = nameElements
+    .map((_, element) => {
+      const name = normalizeComparableText($(element).text());
+      const href = $(element).closest("a[href*='/members/']").attr("href");
+      if (!name || !href) {
+        return null;
+      }
+
+      try {
+        const url = new URL(href, "https://www.assembly.go.kr");
+        if (
+          url.hostname !== "www.assembly.go.kr" ||
+          !url.pathname.includes("/members/")
+        ) {
+          return null;
+        }
+        url.hash = "";
+        return {
+          name,
+          officialProfileUrl: url.toString()
+        };
+      } catch {
+        return null;
+      }
+    })
+    .get()
+    .filter(
+      (
+        reference
+      ): reference is {
+        name: string;
+        officialProfileUrl: string;
+      } => reference !== null
+    );
   const publishedCount = Number.parseInt(
     heading.text().match(/\((\d+)인\)/)?.[1] ?? "",
     10
   );
   return {
     names: [...new Set(names)],
+    memberReferences: [
+      ...new Map(
+        memberReferences.map((reference) => [
+          `${reference.name}:${reference.officialProfileUrl}`,
+          reference
+        ])
+      ).values()
+    ],
     parsedCount: names.length,
     publishedCount: Number.isFinite(publishedCount) ? publishedCount : null
   };
@@ -160,10 +221,82 @@ function assertAttendanceSectionCount(
   }
 }
 
+function normalizeMemberProfileUrlForComparison(value: string): string {
+  try {
+    const url = new URL(value, "https://www.assembly.go.kr");
+    url.hash = "";
+    url.search = "";
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    return url.toString().toLowerCase();
+  } catch {
+    return value.trim().toLowerCase();
+  }
+}
+
+function normalizeLowerPriorityAttendanceSection(args: {
+  names: string[];
+  memberReferences: OfficialAttendanceMemberReference[];
+  higherPriorityNames: ReadonlySet<string>;
+  higherPriorityReferences: OfficialAttendanceMemberReference[];
+}): {
+  names: string[];
+  memberReferences: OfficialAttendanceMemberReference[];
+} {
+  const higherPriorityIdentities = new Set(
+    args.higherPriorityReferences.map((reference) =>
+      [
+        normalizeComparableText(reference.name),
+        normalizeMemberProfileUrlForComparison(reference.officialProfileUrl)
+      ].join(":")
+    )
+  );
+  const memberReferences = args.memberReferences.filter(
+    (reference) =>
+      !higherPriorityIdentities.has(
+        [
+          normalizeComparableText(reference.name),
+          normalizeMemberProfileUrlForComparison(reference.officialProfileUrl)
+        ].join(":")
+      )
+  );
+  const retainedReferenceNames = new Set(
+    memberReferences.map((reference) => reference.name)
+  );
+  const originalReferenceNames = new Set(
+    args.memberReferences.map((reference) => reference.name)
+  );
+  const higherPriorityReferenceNames = new Set(
+    args.higherPriorityReferences.map((reference) =>
+      normalizeComparableText(reference.name)
+    )
+  );
+  const names = args.names.filter((name) => {
+    if (retainedReferenceNames.has(name)) {
+      return true;
+    }
+    if (originalReferenceNames.has(name)) {
+      return false;
+    }
+    // A linked higher-priority row and an unlinked lower-priority row can
+    // represent two different members with the same name. Preserve the
+    // lower-priority row so the fact builder can assign it to the remaining
+    // eligible identity.
+    if (higherPriorityReferenceNames.has(normalizeComparableText(name))) {
+      return true;
+    }
+    return !args.higherPriorityNames.has(name);
+  });
+
+  return { names, memberReferences };
+}
+
 export function parseOfficialMinutesAttendanceHtml(html: string): {
   presentNames: string[];
   leaveNames: string[];
   tripNames: string[];
+  presentMemberReferences: OfficialAttendanceMemberReference[];
+  leaveMemberReferences: OfficialAttendanceMemberReference[];
+  tripMemberReferences: OfficialAttendanceMemberReference[];
 } {
   const present = readAttendanceSection(html, /^◯출석 (?:의원|위원)\s*\(/);
   const leave = readAttendanceSection(html, /^◯청가 (?:의원|위원)\s*\(/);
@@ -171,17 +304,26 @@ export function parseOfficialMinutesAttendanceHtml(html: string): {
   assertAttendanceSectionCount(leave);
   assertAttendanceSectionCount(trip);
   const presentNames = new Set(present.names);
-  const normalizedLeaveNames = leave.names.filter(
-    (name) => !presentNames.has(name)
-  );
-  const leaveNames = new Set(normalizedLeaveNames);
-  const normalizedTripNames = trip.names.filter(
-    (name) => !presentNames.has(name) && !leaveNames.has(name)
-  );
+  const normalizedLeave = normalizeLowerPriorityAttendanceSection({
+    names: leave.names,
+    memberReferences: leave.memberReferences,
+    higherPriorityNames: presentNames,
+    higherPriorityReferences: present.memberReferences
+  });
+  const leaveNames = new Set(normalizedLeave.names);
+  const normalizedTrip = normalizeLowerPriorityAttendanceSection({
+    names: trip.names,
+    memberReferences: trip.memberReferences,
+    higherPriorityNames: new Set([...presentNames, ...leaveNames]),
+    higherPriorityReferences: [
+      ...present.memberReferences,
+      ...normalizedLeave.memberReferences
+    ]
+  });
   const normalizedAttendanceCount =
     present.names.length +
-    normalizedLeaveNames.length +
-    normalizedTripNames.length;
+    normalizedLeave.names.length +
+    normalizedTrip.names.length;
   const publishedPresentCount =
     present.publishedCount === normalizedAttendanceCount
       ? normalizedAttendanceCount
@@ -190,8 +332,11 @@ export function parseOfficialMinutesAttendanceHtml(html: string): {
 
   return {
     presentNames: present.names,
-    leaveNames: normalizedLeaveNames,
-    tripNames: normalizedTripNames
+    leaveNames: normalizedLeave.names,
+    tripNames: normalizedTrip.names,
+    presentMemberReferences: present.memberReferences,
+    leaveMemberReferences: normalizedLeave.memberReferences,
+    tripMemberReferences: normalizedTrip.memberReferences
   };
 }
 
@@ -326,7 +471,10 @@ export async function loadOfficialMinutesAttendanceMeetings(args: {
       attendance = {
         presentNames: [],
         leaveNames: [],
-        tripNames: []
+        tripNames: [],
+        presentMemberReferences: [],
+        leaveMemberReferences: [],
+        tripMemberReferences: []
       };
     }
 
@@ -348,6 +496,9 @@ export async function loadOfficialMinutesAttendanceMeetings(args: {
       absentNames: [],
       leaveNames: attendance.leaveNames,
       tripNames: attendance.tripNames,
+      presentMemberReferences: attendance.presentMemberReferences,
+      leaveMemberReferences: attendance.leaveMemberReferences,
+      tripMemberReferences: attendance.tripMemberReferences,
       requiresExplicitStatus: false,
       sourceUrl: item.sourceUrl,
       retrievedAt:
@@ -414,22 +565,46 @@ export function supplementOfficialMinutesAttendance(args: {
   const fromAttendanceFile = (
     supplement: OfficialPlenaryAttendanceFileMeeting,
     minutesMeeting?: OfficialMinutesAttendanceMeeting
-  ): OfficialMinutesAttendanceMeeting => ({
-    ...(minutesMeeting ?? {
-      documentId: supplement.documentId,
-      meetingDate: supplement.meetingDate,
-      meetingType: "plenary" as const,
-      committeeName: null
-    }),
-    presentNames: supplement.presentNames,
-    absentNames: supplement.absentNames,
-    leaveNames: supplement.leaveNames,
-    tripNames: supplement.tripNames,
-    requiresExplicitStatus: true,
-    sourceUrl: supplement.sourceUrl,
-    retrievedAt: supplement.retrievedAt,
-    sourceHash: supplement.sourceHash
-  });
+  ): OfficialMinutesAttendanceMeeting => {
+    const filterReferences = (
+      references: OfficialAttendanceMemberReference[] | undefined,
+      names: string[]
+    ): OfficialAttendanceMemberReference[] => {
+      const allowedNames = new Set(names.map(normalizeComparableText));
+      return (references ?? []).filter((reference) =>
+        allowedNames.has(normalizeComparableText(reference.name))
+      );
+    };
+
+    return {
+      ...(minutesMeeting ?? {
+        documentId: supplement.documentId,
+        meetingDate: supplement.meetingDate,
+        meetingType: "plenary" as const,
+        committeeName: null
+      }),
+      presentNames: supplement.presentNames,
+      absentNames: supplement.absentNames,
+      leaveNames: supplement.leaveNames,
+      tripNames: supplement.tripNames,
+      presentMemberReferences: filterReferences(
+        minutesMeeting?.presentMemberReferences,
+        supplement.presentNames
+      ),
+      leaveMemberReferences: filterReferences(
+        minutesMeeting?.leaveMemberReferences,
+        supplement.leaveNames
+      ),
+      tripMemberReferences: filterReferences(
+        minutesMeeting?.tripMemberReferences,
+        supplement.tripNames
+      ),
+      requiresExplicitStatus: true,
+      sourceUrl: supplement.sourceUrl,
+      retrievedAt: supplement.retrievedAt,
+      sourceHash: supplement.sourceHash
+    };
+  };
 
   const supplementedMinutes = args.minutesMeetings.flatMap((meeting) => {
     if (meeting.meetingType === "plenary") {

--- a/packages/ingest/src/official-facts.ts
+++ b/packages/ingest/src/official-facts.ts
@@ -47,6 +47,18 @@ function isDateWithinTenure(
   );
 }
 
+function isTenureStartDate(
+  date: string,
+  memberId: string,
+  tenureIndex: MemberTenureIndex
+): boolean {
+  return (tenureIndex.get(memberId) ?? []).some(
+    (period) =>
+      period.startDate === date &&
+      (!period.endDate || date.localeCompare(period.endDate) <= 0)
+  );
+}
+
 function normalizeOfficialProfileUrl(
   value: string | null | undefined
 ): string | null {
@@ -458,6 +470,25 @@ export function buildOfficialAttendanceFacts(args: {
   const currentMembers = args.members.filter(
     (member) => member.isCurrentMember
   );
+  const membersByProfileUrl = new Map<string, MemberRecord[]>();
+  for (const member of currentMembers) {
+    for (const value of [
+      member.officialProfileUrl,
+      member.officialExternalUrl
+    ]) {
+      const profileUrl = normalizeOfficialProfileUrl(value);
+      if (!profileUrl) {
+        continue;
+      }
+      const candidates = membersByProfileUrl.get(profileUrl) ?? [];
+      if (
+        !candidates.some((candidate) => candidate.memberId === member.memberId)
+      ) {
+        candidates.push(member);
+        membersByProfileUrl.set(profileUrl, candidates);
+      }
+    }
+  }
   const facts: AttendanceFactRecord[] = [];
 
   for (const meeting of args.meetings) {
@@ -478,67 +509,179 @@ export function buildOfficialAttendanceFacts(args: {
                 isDateWithinCommitteeCareer(meeting.meetingDate, career)
             )
           );
-    const presentNames = new Set(
-      meeting.presentNames.map(normalizeComparableText)
-    );
-    const absentNames = new Set(
-      (meeting.absentNames ?? []).map(normalizeComparableText)
-    );
-    const leaveNames = new Set(meeting.leaveNames.map(normalizeComparableText));
-    const tripNames = new Set(meeting.tripNames.map(normalizeComparableText));
+    const buildNameCounts = (names: string[]): Map<string, number> => {
+      const counts = new Map<string, number>();
+      for (const value of names) {
+        const name = normalizeComparableText(value);
+        if (name) {
+          counts.set(name, (counts.get(name) ?? 0) + 1);
+        }
+      }
+      return counts;
+    };
+    const nameCountsByStatus = {
+      present: buildNameCounts(meeting.presentNames),
+      absent: buildNameCounts(meeting.absentNames ?? []),
+      leave: buildNameCounts(meeting.leaveNames),
+      trip: buildNameCounts(meeting.tripNames)
+    };
+    const hasAvailableNameStatus = (
+      status: AttendanceFactRecord["status"],
+      name: string
+    ): boolean => (nameCountsByStatus[status].get(name) ?? 0) > 0;
+    const consumeNameStatus = (
+      status: AttendanceFactRecord["status"],
+      name: string
+    ): boolean => {
+      const counts = nameCountsByStatus[status];
+      const count = counts.get(name) ?? 0;
+      if (count <= 0) {
+        return false;
+      }
+      if (count === 1) {
+        counts.delete(name);
+      } else {
+        counts.set(name, count - 1);
+      }
+      return true;
+    };
+    const availableNameStatuses = (
+      name: string
+    ): AttendanceFactRecord["status"][] =>
+      (["present", "absent", "leave", "trip"] as const).filter((status) =>
+        hasAvailableNameStatus(status, name)
+      );
     const eligibleByName = new Map<string, MemberRecord[]>();
+    const eligibleMemberIds = new Set(
+      eligibleMembers.map((member) => member.memberId)
+    );
+    const referencedStatusByMemberId = new Map<
+      string,
+      AttendanceFactRecord["status"]
+    >();
+
+    const addReferencedStatuses = (
+      references:
+        | OfficialMinutesAttendanceMeeting["presentMemberReferences"]
+        | undefined,
+      status: AttendanceFactRecord["status"]
+    ): void => {
+      for (const reference of references ?? []) {
+        const profileUrl = normalizeOfficialProfileUrl(
+          reference.officialProfileUrl
+        );
+        if (!profileUrl) {
+          continue;
+        }
+        const candidates = (membersByProfileUrl.get(profileUrl) ?? []).filter(
+          (member) => eligibleMemberIds.has(member.memberId)
+        );
+        if (candidates.length > 1) {
+          throw new Error(
+            `Official attendance profile URL is ambiguous for ${meeting.documentId}: ${reference.officialProfileUrl}.`
+          );
+        }
+        const member = candidates[0];
+        if (!member) {
+          continue;
+        }
+        const existingStatus = referencedStatusByMemberId.get(member.memberId);
+        if (existingStatus && existingStatus !== status) {
+          throw new Error(
+            `Official attendance profile has conflicting statuses for ${meeting.documentId}: ${member.name}.`
+          );
+        }
+        const referenceName = normalizeComparableText(reference.name);
+        if (!consumeNameStatus(status, referenceName)) {
+          throw new Error(
+            `Official attendance profile has no matching ${status} row for ${meeting.documentId}: ${reference.name}.`
+          );
+        }
+        referencedStatusByMemberId.set(member.memberId, status);
+      }
+    };
+
+    addReferencedStatuses(meeting.presentMemberReferences, "present");
+    addReferencedStatuses(meeting.leaveMemberReferences, "leave");
+    addReferencedStatuses(meeting.tripMemberReferences, "trip");
 
     for (const member of eligibleMembers) {
       const name = normalizeComparableText(member.name);
       eligibleByName.set(name, [...(eligibleByName.get(name) ?? []), member]);
     }
     for (const [name, candidates] of eligibleByName) {
-      if (
-        candidates.length > 1 &&
-        (presentNames.has(name) ||
-          absentNames.has(name) ||
-          leaveNames.has(name) ||
-          tripNames.has(name))
-      ) {
-        throw new Error(
-          `Official attendance name is ambiguous for ${meeting.documentId}: ${name}.`
-        );
-      }
-      if (
-        Number(presentNames.has(name)) +
-          Number(absentNames.has(name)) +
-          Number(leaveNames.has(name)) +
-          Number(tripNames.has(name)) >
-        1
-      ) {
+      const nameStatuses = availableNameStatuses(name);
+      if (nameStatuses.length > 1) {
         throw new Error(
           `Official attendance lists contain conflicting statuses for ${meeting.documentId}: ${name}.`
+        );
+      }
+      if (candidates.length > 1) {
+        const unresolvedCandidates = candidates.filter(
+          (member) => !referencedStatusByMemberId.has(member.memberId)
+        );
+        const status = nameStatuses[0];
+        const availableCount = status
+          ? (nameCountsByStatus[status].get(name) ?? 0)
+          : 0;
+        if (
+          status &&
+          availableCount === unresolvedCandidates.length &&
+          unresolvedCandidates.length > 0
+        ) {
+          for (const member of unresolvedCandidates) {
+            referencedStatusByMemberId.set(member.memberId, status);
+            consumeNameStatus(status, name);
+          }
+        } else if (availableCount > 0) {
+          throw new Error(
+            `Official attendance name is ambiguous for ${meeting.documentId}: ${name}.`
+          );
+        }
+      } else if (
+        nameStatuses[0] &&
+        (nameCountsByStatus[nameStatuses[0]].get(name) ?? 0) > 1
+      ) {
+        throw new Error(
+          `Official attendance list contains duplicate rows for ${meeting.documentId}: ${name}.`
         );
       }
     }
 
     for (const member of eligibleMembers) {
       const name = normalizeComparableText(member.name);
-      if (
-        meeting.requiresExplicitStatus &&
-        !presentNames.has(name) &&
-        !absentNames.has(name) &&
-        !leaveNames.has(name) &&
-        !tripNames.has(name)
-      ) {
+      const sameNameCandidateCount = eligibleByName.get(name)?.length ?? 0;
+      const referencedStatus = referencedStatusByMemberId.get(member.memberId);
+      const useNameStatus = sameNameCandidateCount <= 1;
+      const nameStatus = useNameStatus
+        ? availableNameStatuses(name)[0]
+        : undefined;
+      const hasExplicitStatus =
+        referencedStatus !== undefined || nameStatus !== undefined;
+      if (meeting.requiresExplicitStatus && !hasExplicitStatus) {
+        // Official tenure history has date-only boundaries, while the plenary
+        // attendance workbook is the authoritative roster for each sitting.
+        // A blank on the exact start date can therefore mean that the member
+        // took office after that day's sitting. Keep all other blanks
+        // fail-closed so parser or source omissions cannot become absences.
+        if (
+          meeting.meetingType === "plenary" &&
+          isTenureStartDate(
+            meeting.meetingDate,
+            member.memberId,
+            args.tenureIndex
+          )
+        ) {
+          continue;
+        }
         throw new Error(
           `Official attendance file has no explicit status for ${member.name} on ${meeting.meetingDate}.`
         );
       }
-      const status = presentNames.has(name)
-        ? "present"
-        : absentNames.has(name)
-          ? "absent"
-          : leaveNames.has(name)
-            ? "leave"
-            : tripNames.has(name)
-              ? "trip"
-              : "absent";
+      const status = referencedStatus ?? nameStatus ?? "absent";
+      if (!referencedStatus && nameStatus) {
+        consumeNameStatus(nameStatus, name);
+      }
 
       facts.push({
         attendanceId: `${meeting.documentId}:${member.memberId}`,

--- a/tests/ingest/document-mirror.test.ts
+++ b/tests/ingest/document-mirror.test.ts
@@ -1354,7 +1354,33 @@ describe("document mirror helpers", () => {
     expect(parseOfficialMinutesAttendanceHtml(html)).toEqual({
       presentNames: ["김가람", "이나래"],
       leaveNames: ["박다온"],
-      tripNames: ["최라온"]
+      tripNames: ["최라온"],
+      presentMemberReferences: [
+        {
+          name: "김가람",
+          officialProfileUrl:
+            "https://www.assembly.go.kr/members/official-search-0"
+        },
+        {
+          name: "이나래",
+          officialProfileUrl:
+            "https://www.assembly.go.kr/members/official-search-1"
+        }
+      ],
+      leaveMemberReferences: [
+        {
+          name: "박다온",
+          officialProfileUrl:
+            "https://www.assembly.go.kr/members/official-search-0"
+        }
+      ],
+      tripMemberReferences: [
+        {
+          name: "최라온",
+          officialProfileUrl:
+            "https://www.assembly.go.kr/members/official-search-0"
+        }
+      ]
     });
     const transcript = parseAssemblyMinutesViewerHtml({
       documentId: "assembly-minutes-minutes-52713",

--- a/tests/ingest/official-facts.test.ts
+++ b/tests/ingest/official-facts.test.ts
@@ -4,6 +4,7 @@ import {
   buildOfficialAttendanceFacts,
   mergeOfficialVoteFacts
 } from "../../packages/ingest/src/official-facts.js";
+import { parseOfficialMinutesAttendanceHtml } from "../../packages/ingest/src/official-attendance.js";
 import { buildMeetingId } from "../../packages/ingest/src/parsers/helpers.js";
 
 import type { BillVoteSummaryRecord } from "../../packages/ingest/src/parsers.js";
@@ -518,6 +519,265 @@ describe("official minutes attendance fact completion", () => {
         tenureIndex
       })
     ).toThrow(/no explicit status/);
+  });
+
+  it("uses the official XLSX roster on an exact tenure start date", () => {
+    const newcomer: MemberRecord = {
+      ...lee,
+      memberId: "M-NEWCOMER",
+      name: "이주희",
+      officialProfileUrl: "https://www.assembly.go.kr/members/22nd/LEEJUHEE"
+    };
+    const newcomerTenureIndex: MemberTenureIndex = new Map([
+      [
+        newcomer.memberId,
+        [
+          {
+            startDate: "2025-07-23",
+            endDate: null
+          }
+        ]
+      ]
+    ]);
+    const startDateMeeting = {
+      ...buildMeeting({
+        id: "plenary-tenure-start",
+        date: "2025-07-23",
+        type: "plenary",
+        status: "present"
+      }),
+      presentNames: [],
+      requiresExplicitStatus: true
+    };
+
+    expect(
+      buildOfficialAttendanceFacts({
+        members: [newcomer],
+        careers: [],
+        meetings: [startDateMeeting],
+        tenureIndex: newcomerTenureIndex
+      })
+    ).toEqual([]);
+    expect(
+      buildOfficialAttendanceFacts({
+        members: [newcomer],
+        careers: [],
+        meetings: [
+          {
+            ...startDateMeeting,
+            presentNames: [newcomer.name]
+          }
+        ],
+        tenureIndex: newcomerTenureIndex
+      })
+    ).toMatchObject([
+      {
+        memberId: newcomer.memberId,
+        meetingDate: "2025-07-23",
+        status: "present"
+      }
+    ]);
+    expect(() =>
+      buildOfficialAttendanceFacts({
+        members: [newcomer],
+        careers: [],
+        meetings: [
+          {
+            ...startDateMeeting,
+            documentId: "plenary-after-tenure-start",
+            meetingDate: "2025-07-24"
+          }
+        ],
+        tenureIndex: newcomerTenureIndex
+      })
+    ).toThrow(/no explicit status/);
+  });
+
+  it("uses official profile references to resolve duplicate attendance names", () => {
+    const meeting = {
+      ...buildMeeting({
+        id: "plenary-duplicate-name",
+        date: "2026-06-05",
+        type: "plenary",
+        status: "present"
+      }),
+      presentNames: [seniorPark.name, "朴芝源"],
+      presentMemberReferences: [
+        {
+          name: seniorPark.name,
+          officialProfileUrl: seniorPark.officialProfileUrl!
+        },
+        {
+          name: "朴芝源",
+          officialProfileUrl: newPark.officialProfileUrl!
+        }
+      ],
+      requiresExplicitStatus: true
+    };
+
+    const facts = buildOfficialAttendanceFacts({
+      members: [seniorPark, newPark],
+      careers: [],
+      meetings: [meeting],
+      tenureIndex
+    });
+
+    expect(facts).toHaveLength(2);
+    expect(facts.map((fact) => [fact.memberId, fact.status]).sort()).toEqual(
+      [
+        [seniorPark.memberId, "present"],
+        [newPark.memberId, "present"]
+      ].sort()
+    );
+
+    const splitFacts = buildOfficialAttendanceFacts({
+      members: [seniorPark, newPark],
+      careers: [],
+      meetings: [
+        {
+          ...meeting,
+          documentId: "plenary-duplicate-name-split-status",
+          presentNames: ["朴芝源"],
+          absentNames: [seniorPark.name],
+          presentMemberReferences: [
+            {
+              name: "朴芝源",
+              officialProfileUrl: newPark.officialProfileUrl!
+            }
+          ]
+        }
+      ],
+      tenureIndex
+    });
+
+    expect(
+      splitFacts.map((fact) => [fact.memberId, fact.status]).sort()
+    ).toEqual(
+      [
+        [seniorPark.memberId, "absent"],
+        [newPark.memberId, "present"]
+      ].sort()
+    );
+
+    expect(() =>
+      buildOfficialAttendanceFacts({
+        members: [seniorPark, newPark],
+        careers: [],
+        meetings: [
+          {
+            ...meeting,
+            documentId: "plenary-single-consumed-name-row",
+            presentNames: [seniorPark.name],
+            presentMemberReferences: [
+              {
+                name: seniorPark.name,
+                officialProfileUrl: newPark.officialProfileUrl!
+              }
+            ]
+          }
+        ],
+        tenureIndex
+      })
+    ).toThrow(/no explicit status/);
+
+    const inferredFacts = buildOfficialAttendanceFacts({
+      members: [seniorPark, newPark],
+      careers: [],
+      meetings: [
+        {
+          ...meeting,
+          documentId: "plenary-single-consumed-name-row-inferred",
+          presentNames: [seniorPark.name],
+          presentMemberReferences: [
+            {
+              name: seniorPark.name,
+              officialProfileUrl: newPark.officialProfileUrl!
+            }
+          ],
+          requiresExplicitStatus: false
+        }
+      ],
+      tenureIndex
+    });
+
+    expect(
+      inferredFacts.map((fact) => [fact.memberId, fact.status]).sort()
+    ).toEqual(
+      [
+        [seniorPark.memberId, "absent"],
+        [newPark.memberId, "present"]
+      ].sort()
+    );
+  });
+
+  it("preserves an unlinked lower-priority row for a same-name member", () => {
+    const attendance = parseOfficialMinutesAttendanceHtml(`
+      <p><strong>◯출석 의원 (1인)</strong></p>
+      <div class="con"><a href="/members/22nd/PARKJIEWON"><span class="name">박지원</span></a></div>
+      <p><strong>◯청가 의원 (1인)</strong></p>
+      <div class="con"><span class="name">박지원</span></div>
+    `);
+    const meeting: OfficialMinutesAttendanceMeeting = {
+      documentId: "plenary-partial-same-name-references",
+      meetingDate: "2026-06-05",
+      meetingType: "plenary",
+      committeeName: null,
+      ...attendance,
+      requiresExplicitStatus: true,
+      sourceUrl: "https://www.assembly.go.kr/portal/cnts/cntsCont/dataA.do",
+      retrievedAt: "2026-08-02T00:00:00.000Z",
+      sourceHash: "official-minutes-partial-reference"
+    };
+
+    const facts = buildOfficialAttendanceFacts({
+      members: [seniorPark, newPark],
+      careers: [],
+      meetings: [meeting],
+      tenureIndex
+    });
+
+    expect(facts.map((fact) => [fact.memberId, fact.status]).sort()).toEqual(
+      [
+        [seniorPark.memberId, "present"],
+        [newPark.memberId, "leave"]
+      ].sort()
+    );
+  });
+
+  it("deduplicates equivalent official profile URLs for one member", () => {
+    const member = {
+      ...lee,
+      officialExternalUrl: `${lee.officialProfileUrl}/?source=official`
+    };
+    const meeting = {
+      ...buildMeeting({
+        id: "plenary-equivalent-profile-urls",
+        date: "2026-04-17",
+        type: "plenary",
+        status: "present"
+      }),
+      presentMemberReferences: [
+        {
+          name: member.name,
+          officialProfileUrl: member.officialProfileUrl!
+        }
+      ],
+      requiresExplicitStatus: true
+    };
+
+    expect(
+      buildOfficialAttendanceFacts({
+        members: [member],
+        careers: [],
+        meetings: [meeting],
+        tenureIndex
+      })
+    ).toMatchObject([
+      {
+        memberId: member.memberId,
+        status: "present"
+      }
+    ]);
   });
 
   it("reproduces the current official Lee So-hee attendance snapshot", () => {

--- a/tests/ingest/official-sources.test.ts
+++ b/tests/ingest/official-sources.test.ts
@@ -181,7 +181,24 @@ describe("official committee and minutes attendance sources", () => {
     expect(attendance).toEqual({
       presentNames: ["김 아라", "이 보라"],
       leaveNames: ["박 초록"],
-      tripNames: ["최 파랑"]
+      tripNames: ["최 파랑"],
+      presentMemberReferences: [
+        {
+          name: "김 아라",
+          officialProfileUrl: "https://www.assembly.go.kr/members/1"
+        },
+        {
+          name: "이 보라",
+          officialProfileUrl: "https://www.assembly.go.kr/members/2"
+        }
+      ],
+      leaveMemberReferences: [],
+      tripMemberReferences: [
+        {
+          name: "최 파랑",
+          officialProfileUrl: "https://www.assembly.go.kr/members/4"
+        }
+      ]
     });
 
     expect(
@@ -194,7 +211,10 @@ describe("official committee and minutes attendance sources", () => {
     ).toEqual({
       presentNames: ["김 아라", "이 보라"],
       leaveNames: ["박 초록"],
-      tripNames: []
+      tripNames: [],
+      presentMemberReferences: [],
+      leaveMemberReferences: [],
+      tripMemberReferences: []
     });
 
     expect(
@@ -207,7 +227,10 @@ describe("official committee and minutes attendance sources", () => {
     ).toEqual({
       presentNames: ["김 아라", "이 보라"],
       leaveNames: ["박 초록"],
-      tripNames: []
+      tripNames: [],
+      presentMemberReferences: [],
+      leaveMemberReferences: [],
+      tripMemberReferences: []
     });
 
     expect(
@@ -220,7 +243,36 @@ describe("official committee and minutes attendance sources", () => {
     ).toEqual({
       presentNames: ["김 아라", "이 보라"],
       leaveNames: ["박 초록"],
-      tripNames: []
+      tripNames: [],
+      presentMemberReferences: [],
+      leaveMemberReferences: [],
+      tripMemberReferences: []
+    });
+
+    expect(
+      parseOfficialMinutesAttendanceHtml(`
+        <p><strong>◯출석 의원 (1인)</strong></p>
+        <div class="con"><a href="/members/22nd/PARKA"><span class="name">박지원</span></a></div>
+        <p><strong>◯청가 의원 (1인)</strong></p>
+        <div class="con"><a href="/members/22nd/PARKB"><span class="name">박지원</span></a></div>
+      `)
+    ).toEqual({
+      presentNames: ["박지원"],
+      leaveNames: ["박지원"],
+      tripNames: [],
+      presentMemberReferences: [
+        {
+          name: "박지원",
+          officialProfileUrl: "https://www.assembly.go.kr/members/22nd/PARKA"
+        }
+      ],
+      leaveMemberReferences: [
+        {
+          name: "박지원",
+          officialProfileUrl: "https://www.assembly.go.kr/members/22nd/PARKB"
+        }
+      ],
+      tripMemberReferences: []
     });
   });
 
@@ -402,6 +454,9 @@ describe("official committee and minutes attendance sources", () => {
         ...minutesMeeting,
         presentNames: ["김 아라"],
         absentNames: ["이 보라"],
+        presentMemberReferences: [],
+        leaveMemberReferences: [],
+        tripMemberReferences: [],
         requiresExplicitStatus: true,
         sourceUrl: fileMeeting.sourceUrl,
         retrievedAt: fileMeeting.retrievedAt,
@@ -416,11 +471,68 @@ describe("official committee and minutes attendance sources", () => {
         absentNames: ["이 보라"],
         leaveNames: [],
         tripNames: [],
+        presentMemberReferences: [],
+        leaveMemberReferences: [],
+        tripMemberReferences: [],
         requiresExplicitStatus: true,
         sourceUrl: fileMeeting.sourceUrl,
         retrievedAt: fileMeeting.retrievedAt,
         sourceHash: fileMeeting.sourceHash
       }
+    ]);
+  });
+
+  it("drops stale minutes status references when the official XLSX disagrees", () => {
+    const memberReference = {
+      name: "김 아라",
+      officialProfileUrl: "https://www.assembly.go.kr/members/22nd/KIMARA"
+    };
+    const minutesMeeting = {
+      documentId: "minutes-status-conflict",
+      meetingDate: "2026-06-30",
+      meetingType: "plenary" as const,
+      committeeName: null,
+      presentNames: [memberReference.name],
+      absentNames: [],
+      leaveNames: [],
+      tripNames: [],
+      presentMemberReferences: [memberReference],
+      leaveMemberReferences: [],
+      tripMemberReferences: [],
+      sourceUrl:
+        "https://record.assembly.go.kr/assembly/viewer/minutes/xml.do?id=2&type=view",
+      retrievedAt: "2026-08-01T00:00:00.000Z",
+      sourceHash: "minutes-conflict-hash"
+    };
+    const fileMeeting = {
+      documentId: "file-status-conflict",
+      sessionNo: 436,
+      meetingDate: "2026-06-30",
+      meetingType: "plenary" as const,
+      committeeName: null,
+      presentNames: [],
+      absentNames: [memberReference.name],
+      leaveNames: [],
+      tripNames: [],
+      sourceUrl:
+        "https://open.assembly.go.kr/portal/data/file/downloadFileData.do?fileSeq=2",
+      retrievedAt: "2026-08-02T00:00:00.000Z",
+      sourceHash: "file-conflict-hash"
+    };
+
+    expect(
+      supplementOfficialMinutesAttendance({
+        minutesMeetings: [minutesMeeting],
+        plenaryFileMeetings: [fileMeeting]
+      })
+    ).toEqual([
+      expect.objectContaining({
+        presentNames: [],
+        absentNames: [memberReference.name],
+        presentMemberReferences: [],
+        sourceUrl: fileMeeting.sourceUrl,
+        sourceHash: fileMeeting.sourceHash
+      })
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- preserve official Assembly profile references when reconciling minutes with plenary attendance XLSX files
- resolve same-name members without reusing consumed status rows
- allow an explicitly blank official XLSX roster cell only on the exact tenure start date
- add regression coverage for partial profile references and tenure boundaries

## Verification
- npm test (326 tests)
- npm run typecheck
- npm run lint
- npm run format:check
- full official-data rebuild from ingest run 30733681480
- Lee So-hee: plenary 27/30 present, 2 absent, 1 leave; Culture 5/9; Health 1/1

All runtime inputs remain restricted to official National Assembly/government sources.