### PR TITLE
Handle mixed vote publication dates in Parquet

### DIFF
--- a/packages/ingest/sql/materialize_parquet.sql
+++ b/packages/ingest/sql/materialize_parquet.sql
@@ -1,6 +1,3 @@
-INSTALL httpfs;
-LOAD httpfs;
-
 COPY (
   SELECT * FROM read_ndjson_auto('normalized/members.ndjson')
 ) TO 'curated/members.parquet' (FORMAT PARQUET, COMPRESSION ZSTD);
@@ -10,7 +7,19 @@ COPY (
 ) TO 'curated/roll_calls.parquet' (FORMAT PARQUET, COMPRESSION ZSTD);
 
 COPY (
-  SELECT * FROM read_ndjson_auto('normalized/vote_facts.ndjson')
+  SELECT * FROM read_ndjson(
+    'normalized/vote_facts.ndjson',
+    columns = {
+      rollCallId: 'VARCHAR',
+      memberId: 'VARCHAR',
+      memberName: 'VARCHAR',
+      party: 'VARCHAR',
+      voteCode: 'VARCHAR',
+      publishedAt: 'VARCHAR',
+      retrievedAt: 'VARCHAR',
+      sourceHash: 'VARCHAR'
+    }
+  )
 ) TO 'curated/vote_facts.parquet' (FORMAT PARQUET, COMPRESSION ZSTD);
 
 COPY (

--- a/tests/ingest/materialize-parquet.test.ts
+++ b/tests/ingest/materialize-parquet.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+describe("Parquet materialization", () => {
+  it("keeps mixed-precision vote publication dates as strings", async () => {
+    const sql = await readFile(
+      new URL(
+        "../../packages/ingest/sql/materialize_parquet.sql",
+        import.meta.url
+      ),
+      "utf8"
+    );
+    const voteFactsCopy = sql.match(
+      /COPY \(\s*SELECT \* FROM read_ndjson\([\s\S]*?\)\s*\) TO 'curated\/vote_facts\.parquet'/
+    )?.[0];
+
+    expect(voteFactsCopy).toBeDefined();
+    expect(voteFactsCopy).toContain("publishedAt: 'VARCHAR'");
+    expect(voteFactsCopy).not.toContain("read_ndjson_auto");
+  });
+});


### PR DESCRIPTION
## Summary
- declare the vote-fact NDJSON schema explicitly during Parquet materialization
- keep mixed date-only and timestamp publication values as VARCHAR
- remove the unused httpfs extension dependency
- add a regression contract test

## Verification
- DuckDB 1.1.3 materialized all 584,528 official vote-fact rows
- 57,058 date-only values preserved
- npm test (327 tests)
- typecheck, lint, format, and diff checks passed