### PR TITLE
Bound member card generation latency

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Build web app
+        timeout-minutes: 10
         run: npm run build --workspace @lawmaker-monitor/web
         env:
           VITE_DATA_REPO_BASE_URL: ${{ vars.DATA_REPO_BASE_URL }}

--- a/scripts/generate-member-share-pages.mjs
+++ b/scripts/generate-member-share-pages.mjs
@@ -40,6 +40,7 @@ const STATEMENT_FETCH_CONCURRENCY = 16;
 const SAFE_MEMBER_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const GA_MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]+$/;
 const PORTRAIT_FETCH_ATTEMPTS = 3;
+const ASSEMBLY_PORTRAIT_CIRCUIT_FAILURE_THRESHOLD = 2;
 const PORTRAIT_RETRY_BASE_DELAY_MS = 250;
 const PORTRAIT_RETRY_MAX_DELAY_MS = 2_000;
 const ASSEMBLY_ORIGIN = "https://www.assembly.go.kr";
@@ -239,6 +240,43 @@ function isRetryableResponse(status) {
   return status === 408 || status === 425 || status === 429 || status >= 500;
 }
 
+class AssemblyPortraitCircuitOpenError extends Error {
+  constructor() {
+    super("[member-share] Assembly portrait circuit is open");
+    this.name = "AssemblyPortraitCircuitOpenError";
+  }
+}
+
+export function createAssemblyPortraitCircuit({
+  failureThreshold = ASSEMBLY_PORTRAIT_CIRCUIT_FAILURE_THRESHOLD,
+  onOpen
+} = {}) {
+  let consecutiveFailures = 0;
+  let open = false;
+
+  return {
+    assertAvailable() {
+      if (open) {
+        throw new AssemblyPortraitCircuitOpenError();
+      }
+    },
+    recordFailure() {
+      if (open) {
+        return;
+      }
+
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= failureThreshold) {
+        open = true;
+        onOpen?.();
+      }
+    },
+    recordSuccess() {
+      consecutiveFailures = 0;
+    }
+  };
+}
+
 function readRetryAfterMs(response) {
   const retryAfter = response.headers.get("retry-after");
   if (!retryAfter) {
@@ -265,8 +303,19 @@ async function waitForRetry(delayMs) {
   await new Promise((resolvePromise) => setTimeout(resolvePromise, delayMs));
 }
 
-async function fetchPortraitResource(fetchImpl, url, headers, timeoutMs) {
+async function fetchPortraitResource(
+  fetchImpl,
+  url,
+  headers,
+  timeoutMs,
+  assemblyPortraitCircuit
+) {
   let lastError = null;
+  const usesAssemblyCircuit = assemblyPortraitCircuit && isAssemblyUrl(url);
+
+  if (usesAssemblyCircuit) {
+    assemblyPortraitCircuit.assertAvailable();
+  }
 
   for (let attempt = 0; attempt < PORTRAIT_FETCH_ATTEMPTS; attempt += 1) {
     try {
@@ -278,6 +327,13 @@ async function fetchPortraitResource(fetchImpl, url, headers, timeoutMs) {
         !isRetryableResponse(response.status) ||
         attempt === PORTRAIT_FETCH_ATTEMPTS - 1
       ) {
+        if (usesAssemblyCircuit) {
+          if (isRetryableResponse(response.status)) {
+            assemblyPortraitCircuit.recordFailure();
+          } else {
+            assemblyPortraitCircuit.recordSuccess();
+          }
+        }
         return response;
       }
 
@@ -292,10 +348,19 @@ async function fetchPortraitResource(fetchImpl, url, headers, timeoutMs) {
     }
   }
 
+  if (usesAssemblyCircuit) {
+    assemblyPortraitCircuit.recordFailure();
+  }
   throw lastError ?? new Error("portrait request failed");
 }
 
-async function fetchImageDataUrl(fetchImpl, url, warnings, timeoutMs) {
+async function fetchImageDataUrl(
+  fetchImpl,
+  url,
+  warnings,
+  timeoutMs,
+  assemblyPortraitCircuit
+) {
   const optimizedUrl = getOptimizedPortraitUrl(url);
 
   try {
@@ -303,7 +368,8 @@ async function fetchImageDataUrl(fetchImpl, url, warnings, timeoutMs) {
       fetchImpl,
       optimizedUrl,
       isAssemblyUrl(optimizedUrl) ? ASSEMBLY_REQUEST_HEADERS : undefined,
-      timeoutMs
+      timeoutMs,
+      assemblyPortraitCircuit
     );
     if (!response.ok) {
       warnings.push(`${optimizedUrl} image returned ${response.status}`);
@@ -332,6 +398,9 @@ async function fetchImageDataUrl(fetchImpl, url, warnings, timeoutMs) {
 
     return `data:${contentType};base64,${image.toString("base64")}`;
   } catch (error) {
+    if (error instanceof AssemblyPortraitCircuitOpenError) {
+      return null;
+    }
     warnings.push(
       `${optimizedUrl} image could not be loaded: ${
         error instanceof Error ? error.message : String(error)
@@ -413,14 +482,16 @@ export async function resolveMemberPortraitDataUrl({
   assemblyNo,
   fetchImpl,
   warnings,
-  timeoutMs
+  timeoutMs,
+  assemblyPortraitCircuit
 }) {
   if (member.photoUrl) {
     const publishedPhoto = await fetchImageDataUrl(
       fetchImpl,
       member.photoUrl,
       warnings,
-      timeoutMs
+      timeoutMs,
+      assemblyPortraitCircuit
     );
     if (publishedPhoto) {
       return publishedPhoto;
@@ -435,7 +506,8 @@ export async function resolveMemberPortraitDataUrl({
       fetchImpl,
       memberPageUrl,
       ASSEMBLY_REQUEST_HEADERS,
-      timeoutMs
+      timeoutMs,
+      assemblyPortraitCircuit
     );
     if (!response.ok) {
       warnings.push(`${memberPageUrl} returned ${response.status}`);
@@ -449,6 +521,9 @@ export async function resolveMemberPortraitDataUrl({
       }
     }
   } catch (error) {
+    if (error instanceof AssemblyPortraitCircuitOpenError) {
+      throw error;
+    }
     warnings.push(
       `${memberPageUrl} could not be loaded: ${
         error instanceof Error ? error.message : String(error)
@@ -461,7 +536,8 @@ export async function resolveMemberPortraitDataUrl({
       fetchImpl,
       officialPhotoUrl,
       warnings,
-      timeoutMs
+      timeoutMs,
+      assemblyPortraitCircuit
     );
     if (officialPhoto) {
       return officialPhoto;
@@ -1118,6 +1194,13 @@ export async function generateMemberSharePages({
     assemblyNo
   };
   const manifestEntries = [];
+  const assemblyPortraitCircuit = createAssemblyPortraitCircuit({
+    onOpen: () => {
+      warnings.push(
+        `[member-share] Assembly portrait circuit opened after ${ASSEMBLY_PORTRAIT_CIRCUIT_FAILURE_THRESHOLD} consecutive unavailable resources; reusing published cards for remaining members`
+      );
+    }
+  });
 
   await runInBatches(members, CARD_GENERATION_CONCURRENCY, async (member) => {
     let portraitDataUrl = null;
@@ -1128,11 +1211,14 @@ export async function generateMemberSharePages({
         assemblyNo: context.assemblyNo,
         fetchImpl,
         warnings,
-        timeoutMs
+        timeoutMs,
+        assemblyPortraitCircuit
       });
     } catch (error) {
       portraitError = error;
-      warnings.push(error instanceof Error ? error.message : String(error));
+      if (!(error instanceof AssemblyPortraitCircuitOpenError)) {
+        warnings.push(error instanceof Error ? error.message : String(error));
+      }
     }
     const model = buildMemberCardModel(
       {

--- a/tests/ingest/member-share-pages.test.ts
+++ b/tests/ingest/member-share-pages.test.ts
@@ -389,6 +389,104 @@ describe("generateMemberSharePages", () => {
       })
     ).rejects.toThrow("no valid member data was available");
   });
+
+  it("opens the Assembly circuit and reuses published cards for remaining members", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const distDir = await createTemporaryDirectory();
+      const members = [
+        { memberId: "M001", name: "가의원" },
+        { memberId: "M002", name: "나의원" },
+        { memberId: "M003", name: "다의원" },
+        { memberId: "M004", name: "라의원" }
+      ].map((member) => ({
+        ...member,
+        party: "테스트당",
+        photoUrl: `https://www.assembly.go.kr/static/portal/img/openassm/new/${member.memberId}.jpg`
+      }));
+      const payloads: Record<string, unknown> = {
+        "https://data.example.test/manifests/latest.json": {
+          snapshotId: "snapshot-circuit",
+          updatedAt: "2026-08-04T00:00:00.000Z",
+          currentAssembly: { assemblyNo: 22, label: "제22대 국회" },
+          exports: {}
+        },
+        "https://data.example.test/exports/member_activity_calendar.json": {
+          generatedAt: "2026-08-04T00:00:00.000Z",
+          assemblyLabel: "제22대 국회",
+          assembly: { members }
+        },
+        "https://data.example.test/exports/accountability_summary.json": {
+          items: []
+        },
+        "https://data.example.test/exports/member_assets_index.json": {
+          members: []
+        },
+        "https://data.example.test/exports/bill_proposal_activity.json": {
+          items: []
+        },
+        "https://data.example.test/exports/member_statement_summaries/index.json":
+          {
+            members: []
+          }
+      };
+      const assemblyRequests: string[] = [];
+      const publishedCardRequests: string[] = [];
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.startsWith("https://www.assembly.go.kr/")) {
+          assemblyRequests.push(url);
+          throw new Error("The operation was aborted due to timeout");
+        }
+        if (
+          url.startsWith(
+            "https://app.example.test/lawmaker-monitor/member-cards/"
+          )
+        ) {
+          publishedCardRequests.push(url);
+          return new Response(onePixelPng, {
+            status: 200,
+            headers: { "Content-Type": "image/png" }
+          });
+        }
+
+        const payload = payloads[url];
+        return payload
+          ? new Response(JSON.stringify(payload), {
+              status: 200,
+              headers: { "Content-Type": "application/json" }
+            })
+          : new Response(null, { status: 404 });
+      });
+
+      const generation = generateMemberSharePages({
+        distDir,
+        appBaseUrl: "https://app.example.test/lawmaker-monitor/",
+        dataRepoBaseUrl: "https://data.example.test/",
+        fetchImpl,
+        timeoutMs: 10
+      });
+
+      await vi.runAllTimersAsync();
+      const result = await generation;
+
+      expect(result).toMatchObject({ status: "generated", count: 4 });
+      expect(
+        assemblyRequests.some(
+          (url) => url.includes("M003") || url.includes("M004")
+        )
+      ).toBe(false);
+      expect(assemblyRequests.length).toBeLessThan(24);
+      expect(publishedCardRequests).toHaveLength(4);
+      expect(
+        result.warnings.filter((warning) =>
+          warning.includes("Assembly portrait circuit opened")
+        )
+      ).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("member share portraits", () => {


### PR DESCRIPTION
## What changed

- add a shared circuit breaker for National Assembly portrait requests
- reuse previously published verified cards after two consecutive unavailable Assembly resources
- cap the web build step at 10 minutes
- add a regression test proving later members skip Assembly requests after the circuit opens

## Why

GitHub-hosted runners can intermittently time out while fetching 298 Assembly portraits. The existing per-member retries multiplied into deployments lasting about two hours. This change bounds the outage path while preserving the existing verified-card fallback and failing safely for members without a verified portrait or published card.

## Validation

- `npm test` — 329 tests passed
- `npm run typecheck`
- Prettier and ESLint checks
- live build against the production data repository — 298 member pages generated successfully