### PR TITLE
fix member detail navigation

### DIFF
--- a/apps/web/src/components/ActivityCalendarPage.tsx
+++ b/apps/web/src/components/ActivityCalendarPage.tsx
@@ -3137,7 +3137,7 @@ export function ActivityCalendarPage({
                     />
                   </section>
                   <ActivityRatioChart member={selectedMember} />
-                  <div id="member-assets">
+                  <div id="member-assets" tabIndex={-1}>
                     <MemberAssetSection
                       indexEntry={selectedMemberAssetIndex}
                       indexError={memberAssetsIndexError}
@@ -3152,10 +3152,10 @@ export function ActivityCalendarPage({
                       memberId={selectedMember.memberId}
                     />
                   </div>
-                  <div id="member-committees">
+                  <div id="member-committees" tabIndex={-1}>
                     <ActivityCommitteeSections member={selectedMember} />
                   </div>
-                  <div id="member-votes">
+                  <div id="member-votes" tabIndex={-1}>
                     <ActivityVoteRecordSections
                       records={
                         selectedMemberDetail?.voteRecords ??

--- a/apps/web/src/components/MemberEvaluationDossier.tsx
+++ b/apps/web/src/components/MemberEvaluationDossier.tsx
@@ -77,7 +77,7 @@ type EvidenceItem = {
   value: string;
   detail: string;
   status: string;
-  href?: string;
+  targetId?: string;
 };
 
 type LedgerRow = {
@@ -185,6 +185,30 @@ function getShareLabel(state: MemberEvaluationShareState): string {
   return "공유";
 }
 
+function MemberSectionButton({
+  targetId,
+  children
+}: {
+  targetId: string;
+  children: ReactNode;
+}) {
+  function handleClick() {
+    const target = document.getElementById(targetId);
+    if (!target) {
+      return;
+    }
+
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    target.focus({ preventScroll: true });
+  }
+
+  return (
+    <button type="button" aria-controls={targetId} onClick={handleClick}>
+      {children}
+    </button>
+  );
+}
+
 function EvidenceColumn({
   tone,
   icon,
@@ -221,11 +245,11 @@ function EvidenceColumn({
             <p>{item.detail}</p>
             <footer>
               <small>{item.status}</small>
-              {item.href ? (
-                <a href={item.href}>
+              {item.targetId ? (
+                <MemberSectionButton targetId={item.targetId}>
                   자세히
                   <ArrowRightIcon size={15} weight="bold" aria-hidden="true" />
-                </a>
+                </MemberSectionButton>
               ) : null}
             </footer>
           </div>
@@ -398,7 +422,7 @@ export function MemberEvaluationDossier({
         )}건 · 확인 불가 ${formatNumber(
           participationSnapshot.unresolvedCount
         )}건`,
-        href: "#member-votes"
+        targetId: "member-votes"
       });
     } else if (
       accountabilityItem &&
@@ -415,7 +439,7 @@ export function MemberEvaluationDossier({
         status: `확인 불가 ${formatNumber(
           participationSnapshot.unresolvedCount
         )}건 · 불참으로 추론하지 않음`,
-        href: "#member-votes"
+        targetId: "member-votes"
       });
     } else {
       items.push({
@@ -510,7 +534,7 @@ export function MemberEvaluationDossier({
         value: `${formatNumber(committeeNames.length)}곳`,
         detail: committeeNames.join(", "),
         status: `기준: ${assembly.label} 공개 소속 정보`,
-        href: "#member-committees"
+        targetId: "member-committees"
       });
     }
 
@@ -561,7 +585,7 @@ export function MemberEvaluationDossier({
         detail:
           "불참 사유는 표결 기록만으로 알 수 없어 원문·공식 설명 확인이 필요합니다.",
         status: reviewStatus,
-        href: "#member-votes"
+        targetId: "member-votes"
       },
       {
         id: "no-votes",
@@ -569,7 +593,7 @@ export function MemberEvaluationDossier({
         value: reviewValue(accountabilityItem.noCount),
         detail: "반대 여부는 의안별 판단 기록이며 평가 점수가 아닙니다.",
         status: reviewStatus,
-        href: "#member-votes"
+        targetId: "member-votes"
       },
       {
         id: "abstain-votes",
@@ -577,7 +601,7 @@ export function MemberEvaluationDossier({
         value: reviewValue(accountabilityItem.abstainCount),
         detail: "기권 여부도 의안별 판단 기록이며 평가 점수가 아닙니다.",
         status: reviewStatus,
-        href: "#member-votes"
+        targetId: "member-votes"
       }
     ];
 
@@ -662,7 +686,7 @@ export function MemberEvaluationDossier({
           latestAssetPoint.currentAmount
         )} (${formatDate(latestAssetPoint.reportedAt)})`,
         status: "동일 의원의 연속 공개 신고 · 원인 단정 불가",
-        href: "#member-assets"
+        targetId: "member-assets"
       });
     } else if (latestAssetSummary) {
       items.push({
@@ -675,7 +699,7 @@ export function MemberEvaluationDossier({
           : assetHistoryError
             ? "이전 신고 이력을 불러오지 못해 변화 비교 보류"
             : "이전 신고 기준일이 없어 변화 비교 보류",
-        href: "#member-assets"
+        targetId: "member-assets"
       });
     } else {
       items.push({
@@ -1133,10 +1157,10 @@ export function MemberEvaluationDossier({
           </div>
           <div>
             <strong>총 {formatNumber(voteRecordCount)}건</strong>
-            <a href="#member-votes">
+            <MemberSectionButton targetId="member-votes">
               전체 기록 보기
               <ArrowRightIcon size={16} weight="bold" aria-hidden="true" />
-            </a>
+            </MemberSectionButton>
           </div>
         </header>
 

--- a/apps/web/src/styles/member-evaluation.css
+++ b/apps/web/src/styles/member-evaluation.css
@@ -270,8 +270,8 @@
 
 .member-evaluation__identity-actions :is(a, button):focus-visible,
 .member-evaluation__question-tabs button:focus-visible,
-.member-evaluation__evidence-item a:focus-visible,
-.member-evaluation__source-records a:focus-visible,
+.member-evaluation__evidence-item button:focus-visible,
+.member-evaluation__source-records :is(a, button):focus-visible,
 .member-evaluation__table-scroll:focus-visible {
   outline: 3px solid color-mix(in srgb, var(--accent) 58%, white);
   outline-offset: 2px;
@@ -482,14 +482,17 @@
   line-height: 1.4;
 }
 
-.member-evaluation__evidence-item a {
+.member-evaluation__evidence-item button {
   display: inline-flex;
   min-height: 2.75rem;
   flex: 0 0 auto;
   align-items: center;
   gap: 0.22rem;
   padding-inline: 0.2rem;
+  border: 0;
+  background: transparent;
   color: var(--accent-strong);
+  cursor: pointer;
   font-size: 0.7rem;
   font-weight: 850;
   text-decoration: underline;
@@ -696,13 +699,17 @@
   gap: 0.75rem;
 }
 
-.member-evaluation__source-records > header a,
+.member-evaluation__source-records > header button,
 .member-evaluation__records-table a {
   display: inline-flex;
   min-height: 2.75rem;
   align-items: center;
   gap: 0.3rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--accent-strong);
+  cursor: pointer;
   font-size: 0.72rem;
   font-weight: 850;
   text-decoration: underline;

--- a/tests/web/member-evaluation-dossier.test.tsx
+++ b/tests/web/member-evaluation-dossier.test.tsx
@@ -234,4 +234,46 @@ describe("member evaluation dossier", () => {
     expect(getByText("지역 정보 미확인")).toBeInTheDocument();
     expect(queryByText("비례대표")).not.toBeInTheDocument();
   });
+
+  it("scrolls to evidence without replacing the hash route", () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView
+    });
+    window.history.replaceState(null, "", "#calendar?member=M001");
+
+    const { container } = render(
+      <>
+        <MemberEvaluationDossier
+          assembly={activity.assembly}
+          member={member}
+          accountabilityItem={accountabilityItem}
+          voteRecords={[]}
+          voteRecordCount={0}
+          voteRecordsLoading={false}
+          voteRecordsError={null}
+          resolvedDistrict="서울 중구"
+          onShare={vi.fn()}
+        />
+        <div id="member-votes" tabIndex={-1} />
+      </>
+    );
+    const evidenceGrid = container.querySelector(
+      ".member-evaluation__evidence-grid"
+    );
+    const firstDetailButton = within(evidenceGrid!).getAllByRole("button", {
+      name: "자세히"
+    })[0]!;
+
+    fireEvent.click(firstDetailButton);
+
+    const target = container.querySelector("#member-votes");
+    expect(window.location.hash).toBe("#calendar?member=M001");
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start"
+    });
+    expect(document.activeElement).toBe(target);
+  });
 });


### PR DESCRIPTION
## What changed
- replace hash-based in-page detail links with dedicated section buttons
- preserve the current calendar route while smoothly scrolling to votes, committees, or assets
- move keyboard focus to the destination section
- add a regression test covering route preservation and focus movement

## Root cause
The application uses the URL hash for SPA routing. Detail links such as `#member-votes` replaced the calendar route hash, so the router interpreted the unknown path as the home route.

## Validation
- 330 tests passed
- TypeScript typecheck passed
- ESLint passed
- Prettier passed
- `git diff --check` passed