### PR TITLE
Stop recursive minutes summary runs

### DIFF
--- a/.github/workflows/summarize-minutes.yml
+++ b/.github/workflows/summarize-minutes.yml
@@ -170,23 +170,6 @@ jobs:
             exports/vote_minutes_opinions.json \
             manifests/minutes_summary_state.json
 
-      - name: Continue pending minutes summaries
-        if: >-
-          steps.transcript-inputs.outputs.available == 'true' &&
-          steps.summary-progress.outputs.remaining_documents != '0' &&
-          (
-            steps.summary-progress.outputs.documents_completed != '0' ||
-            steps.summary-progress.outputs.groups_summarized != '0'
-          )
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run summarize-minutes.yml \
-            --ref "${{ github.event.repository.default_branch }}" \
-            -f max_documents="${MINUTES_SUMMARY_MAX_DOCUMENTS}" \
-            -f max_groups="${MINUTES_SUMMARY_MAX_GROUPS}" \
-            -f retry_attempt="0"
-
   retry-failed-summary:
     needs: summarize-minutes
     if: ${{ always() && needs.summarize-minutes.result == 'failure' }}

--- a/tests/ingest/minutes-incremental-workflow.test.ts
+++ b/tests/ingest/minutes-incremental-workflow.test.ts
@@ -58,7 +58,7 @@ describe("incremental minutes workflows", () => {
     expect(workflow).toContain('-f retry_attempt="0"');
   });
 
-  it("keeps AI summarization in small checkpointed batches", () => {
+  it("keeps AI summarization in small checkpointed batches without recursive continuations", () => {
     const workflow = readRepositoryFile(
       ".github/workflows/summarize-minutes.yml"
     );
@@ -73,11 +73,12 @@ describe("incremental minutes workflows", () => {
     );
     expect(workflow).toContain("timeout-minutes: 30");
     expect(workflow).toContain("Commit and push summary changes");
-    expect(workflow).toContain("Continue pending minutes summaries");
+    expect(workflow).not.toContain("Continue pending minutes summaries");
     expect(workflow).toContain("group: published-data-${{ vars.DATA_REPO");
     expect(workflow).toContain("queue: max");
     expect(workflow).toContain("Retry failed summary batch");
-    expect(workflow).toContain('-f retry_attempt="0"');
+    expect(workflow).toContain('MAX_RETRY_ATTEMPTS: "3"');
+    expect(workflow).toContain('-f retry_attempt="${NEXT_RETRY_ATTEMPT}"');
     expect(workflow).not.toContain("workflow_run:");
   });
 


### PR DESCRIPTION
## What changed
- remove the successful-batch self-dispatch from the minutes summarization workflow
- keep the bounded failure retry path (maximum 3 attempts)
- update the workflow regression test to prevent recursive continuations

## Why
Each successful one-document batch immediately dispatched another workflow. Those runs committed to the data repository roughly every two minutes, continuously cancelling the GitHub Pages deployment before it could finish.

## Impact
Minutes summaries still run in bounded batches when triggered, and transient failures still retry. Successful batches no longer create an unbounded workflow chain that starves data Pages deployments.

## Validation
- `npm run typecheck`
- `npm test` (63 files, 330 tests)
- focused workflow test
- Prettier check
- `git diff --check`