### PR TITLE
Summarize only today's Assembly minutes

### DIFF
--- a/.github/workflows/mirror-documents.yml
+++ b/.github/workflows/mirror-documents.yml
@@ -3,25 +3,11 @@ name: mirror-documents
 on:
   workflow_dispatch:
     inputs:
-      backfill_start_date:
-        description: Optional cursor override in YYYY-MM-DD format
-        required: false
-        type: string
-      backfill_windows:
-        description: Number of seven-day backfill windows to process
-        required: false
-        default: "1"
-        type: string
       max_downloads:
-        description: Maximum unique documents to process
+        description: Maximum same-day documents to process
         required: false
-        default: "500"
+        default: "20"
         type: string
-      skip_recent:
-        description: Skip the rolling recent-date window
-        required: false
-        default: false
-        type: boolean
       retry_existing_only:
         description: Revalidate and repair only indexed official Assembly minutes
         required: false
@@ -69,22 +55,15 @@ jobs:
       MIRROR_DATE_SELECTOR: ${{ vars.MIRROR_DATE_SELECTOR }}
       MIRROR_NEXT_SELECTOR: ${{ vars.MIRROR_NEXT_SELECTOR }}
       MIRROR_MAX_PAGES: ${{ vars.MIRROR_MAX_PAGES }}
-      MIRROR_MAX_DOWNLOADS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_downloads || vars.MIRROR_MAX_DOWNLOADS || '500' }}
+      MIRROR_MAX_DOWNLOADS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_downloads || vars.MIRROR_MAX_DOWNLOADS || '20' }}
       MIRROR_DOWNLOAD_CONCURRENCY: ${{ vars.MIRROR_DOWNLOAD_CONCURRENCY || '4' }}
       MIRROR_ASSEMBLY_NO: ${{ vars.MIRROR_ASSEMBLY_NO || '22' }}
       MIRROR_PAGE_SIZE: ${{ vars.MIRROR_PAGE_SIZE || '100' }}
       MIRROR_PAGE_DELAY_MS: ${{ vars.MIRROR_PAGE_DELAY_MS }}
       MIRROR_TIMEOUT_MS: "60000"
       MIRROR_TIME_ZONE: ${{ vars.MIRROR_TIME_ZONE }}
-      MIRROR_RECENT_DAYS: ${{ vars.MIRROR_RECENT_DAYS }}
-      MIRROR_MIN_RECENT_DAYS: ${{ vars.MIRROR_MIN_RECENT_DAYS || '30' }}
-      MIRROR_BACKFILL_START_DATE: ${{ vars.MIRROR_BACKFILL_START_DATE }}
-      MIRROR_BACKFILL_DAYS: ${{ vars.MIRROR_BACKFILL_DAYS }}
-      MIRROR_BACKFILL_CURSOR_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_start_date || '' }}
-      MIRROR_BACKFILL_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_BACKFILL_WINDOWS_PER_RUN || '1' }}
-      MIRROR_CATCHUP_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_CATCHUP_WINDOWS_PER_RUN || '2' }}
-      MIRROR_SKIP_RECENT: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_recent || 'false' }}
       MIRROR_RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}
+      MIRROR_LATEST_DATE_ONLY: "true"
       MIRROR_INCLUDE_APPENDICES: "false"
     steps:
       - name: Checkout repository
@@ -162,8 +141,7 @@ jobs:
         if: env.DATA_REPO != '' && env.DATA_REPO_PAT != ''
         run: |
           STATE_FILE="published-data/manifests/document_mirror_state.json"
-          echo "pending_backfill=$(jq -r '.pendingBackfill // false' "${STATE_FILE}")" >> "${GITHUB_OUTPUT}"
-          echo "backfill_advanced=$(jq -r '.backfillAdvanced // false' "${STATE_FILE}")" >> "${GITHUB_OUTPUT}"
+          echo "cutoff_date=$(jq -r '.cutoffDate' "${STATE_FILE}")" >> "${GITHUB_OUTPUT}"
 
       - name: Validate indexed minutes repair
         if: env.MIRROR_RETRY_EXISTING_ONLY == 'true'
@@ -184,22 +162,9 @@ jobs:
         run: |
           gh workflow run summarize-minutes.yml \
             --ref "${{ github.event.repository.default_branch }}" \
-            -f retry_attempt="0"
-
-      - name: Continue pending minutes backfill
-        if: >-
-          env.MIRROR_RETRY_EXISTING_ONLY != 'true' &&
-          steps.mirror-progress.outputs.pending_backfill == 'true' &&
-          steps.mirror-progress.outputs.backfill_advanced == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow run mirror-documents.yml \
-            --ref "${{ github.event.repository.default_branch }}" \
-            -f backfill_windows="${MIRROR_CATCHUP_WINDOWS_PER_RUN}" \
-            -f max_downloads="${MIRROR_MAX_DOWNLOADS}" \
-            -f skip_recent=true \
-            -f retry_existing_only="${MIRROR_RETRY_EXISTING_ONLY}" \
+            -f target_date="${{ steps.mirror-progress.outputs.cutoff_date }}" \
+            -f max_documents="20" \
+            -f max_groups="160" \
             -f retry_attempt="0"
 
   retry-failed-mirror:
@@ -217,10 +182,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           CURRENT_RETRY_ATTEMPT: ${{ inputs.retry_attempt || '0' }}
           MAX_RETRY_ATTEMPTS: "3"
-          BACKFILL_START_DATE: ${{ inputs.backfill_start_date || '' }}
-          BACKFILL_WINDOWS: ${{ inputs.backfill_windows || '1' }}
-          MAX_DOWNLOADS: ${{ inputs.max_downloads || vars.MIRROR_MAX_DOWNLOADS || '500' }}
-          SKIP_RECENT: ${{ inputs.skip_recent || 'false' }}
+          MAX_DOWNLOADS: ${{ inputs.max_downloads || vars.MIRROR_MAX_DOWNLOADS || '20' }}
           RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}
         run: |
           if ! [[ "${CURRENT_RETRY_ATTEMPT}" =~ ^[0-9]+$ ]]; then
@@ -237,14 +199,9 @@ jobs:
           ARGS=(
             workflow run mirror-documents.yml
             --ref "${{ github.event.repository.default_branch }}"
-            -f "backfill_windows=${BACKFILL_WINDOWS}"
             -f "max_downloads=${MAX_DOWNLOADS}"
-            -f "skip_recent=${SKIP_RECENT}"
             -f "retry_existing_only=${RETRY_EXISTING_ONLY}"
             -f "retry_attempt=${NEXT_RETRY_ATTEMPT}"
           )
-          if [ -n "${BACKFILL_START_DATE}" ]; then
-            ARGS+=(-f "backfill_start_date=${BACKFILL_START_DATE}")
-          fi
 
           gh "${ARGS[@]}"

--- a/.github/workflows/summarize-minutes.yml
+++ b/.github/workflows/summarize-minutes.yml
@@ -3,15 +3,19 @@ name: summarize-minutes
 on:
   workflow_dispatch:
     inputs:
+      target_date:
+        description: Korean calendar date to summarize in YYYY-MM-DD format
+        required: false
+        type: string
       max_documents:
         description: Maximum transcript documents to summarize
         required: false
-        default: "1"
+        default: "20"
         type: string
       max_groups:
         description: Maximum member-agenda groups to summarize
         required: false
-        default: "8"
+        default: "160"
         type: string
       retry_attempt:
         description: Automatic recovery attempt
@@ -27,7 +31,9 @@ concurrency:
 jobs:
   summarize-minutes:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
+    outputs:
+      target_date: ${{ steps.summary-date.outputs.value }}
     permissions:
       actions: write
       contents: read
@@ -38,9 +44,10 @@ jobs:
       LLAMA_CPP_RELEASE: ${{ vars.LLAMA_CPP_RELEASE || 'b10107' }}
       MINUTES_SUMMARY_MODEL: ${{ vars.MINUTES_SUMMARY_MODEL || 'LGAI-EXAONE/EXAONE-4.0-1.2B-GGUF:Q8_0' }}
       MINUTES_SUMMARY_CHAT_TEMPLATE_URL: ${{ vars.MINUTES_SUMMARY_CHAT_TEMPLATE_URL || 'https://huggingface.co/LGAI-EXAONE/EXAONE-4.0-1.2B-GGUF/resolve/162446400ea4596377a3ce1d3ddffa32971af0a6/chat_template.jinja' }}
-      MINUTES_SUMMARY_MAX_DOCUMENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_documents || vars.MINUTES_SUMMARY_MAX_DOCUMENTS || '1' }}
-      MINUTES_SUMMARY_MAX_GROUPS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_groups || vars.MINUTES_SUMMARY_MAX_GROUPS || '8' }}
-      MINUTES_SUMMARY_CONCURRENCY: ${{ vars.MINUTES_SUMMARY_CONCURRENCY || '2' }}
+      MINUTES_SUMMARY_TARGET_DATE: ${{ inputs.target_date }}
+      MINUTES_SUMMARY_MAX_DOCUMENTS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_documents || vars.MINUTES_SUMMARY_MAX_DOCUMENTS || '20' }}
+      MINUTES_SUMMARY_MAX_GROUPS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_groups || vars.MINUTES_SUMMARY_MAX_GROUPS || '160' }}
+      MINUTES_SUMMARY_CONCURRENCY: ${{ vars.MINUTES_SUMMARY_CONCURRENCY || '4' }}
       MINUTES_SUMMARY_REQUEST_TIMEOUT_MS: ${{ vars.MINUTES_SUMMARY_REQUEST_TIMEOUT_MS || '60000' }}
     steps:
       - name: Checkout repository
@@ -58,11 +65,29 @@ jobs:
           TARGET_BRANCH="${DATA_REPO_BRANCH:-main}"
           git clone --depth 1 --branch "${TARGET_BRANCH}" "${REPO_URL}" published-data
 
+      - name: Resolve Korean summary date
+        id: summary-date
+        if: env.DATA_REPO != '' && env.DATA_REPO_PAT != ''
+        run: |
+          TARGET_DATE="${MINUTES_SUMMARY_TARGET_DATE}"
+          if [ -z "${TARGET_DATE}" ]; then
+            TARGET_DATE="$(TZ=Asia/Seoul date +%F)"
+          fi
+          if ! [[ "${TARGET_DATE}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "Invalid summary target date: ${TARGET_DATE}" >&2
+            exit 1
+          fi
+          echo "MINUTES_SUMMARY_TARGET_DATE=${TARGET_DATE}" >> "${GITHUB_ENV}"
+          echo "value=${TARGET_DATE}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect mirrored transcript inputs
         id: transcript-inputs
         if: env.DATA_REPO != '' && env.DATA_REPO_PAT != ''
         run: |
-          if jq -e 'any(.items[]; (.transcriptRelativePath // "") != "")' published-data/raw/index/document_index.json >/dev/null; then
+          if jq -e \
+            --arg target_date "${MINUTES_SUMMARY_TARGET_DATE}" \
+            'any(.items[]; .publishedDate == $target_date and (.transcriptRelativePath // "") != "")' \
+            published-data/raw/index/document_index.json >/dev/null; then
             echo "available=true" >> "${GITHUB_OUTPUT}"
           else
             echo "available=false" >> "${GITHUB_OUTPUT}"
@@ -184,8 +209,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CURRENT_RETRY_ATTEMPT: ${{ inputs.retry_attempt || '0' }}
           MAX_RETRY_ATTEMPTS: "3"
-          MAX_DOCUMENTS: ${{ inputs.max_documents || vars.MINUTES_SUMMARY_MAX_DOCUMENTS || '1' }}
-          MAX_GROUPS: ${{ inputs.max_groups || vars.MINUTES_SUMMARY_MAX_GROUPS || '8' }}
+          TARGET_DATE: ${{ needs.summarize-minutes.outputs.target_date || inputs.target_date }}
+          MAX_DOCUMENTS: ${{ inputs.max_documents || vars.MINUTES_SUMMARY_MAX_DOCUMENTS || '20' }}
+          MAX_GROUPS: ${{ inputs.max_groups || vars.MINUTES_SUMMARY_MAX_GROUPS || '160' }}
         run: |
           if ! [[ "${CURRENT_RETRY_ATTEMPT}" =~ ^[0-9]+$ ]]; then
             echo "Invalid retry attempt: ${CURRENT_RETRY_ATTEMPT}" >&2
@@ -200,6 +226,7 @@ jobs:
 
           gh workflow run summarize-minutes.yml \
             --ref "${{ github.event.repository.default_branch }}" \
+            -f target_date="${TARGET_DATE}" \
             -f max_documents="${MAX_DOCUMENTS}" \
             -f max_groups="${MAX_GROUPS}" \
             -f retry_attempt="${NEXT_RETRY_ATTEMPT}"

--- a/packages/ingest/src/assembly-mirror-policy.ts
+++ b/packages/ingest/src/assembly-mirror-policy.ts
@@ -16,6 +16,7 @@ type SearchWindowOptions = {
   includeAllBackfillWindows?: boolean;
   backfillCursorDate?: string;
   includeRecent?: boolean;
+  latestDateOnly?: boolean;
   maxBackfillWindows?: number;
 };
 
@@ -59,6 +60,16 @@ export function buildAssemblySearchWindows(
   existingState: Pick<DocumentMirrorState, "nextBackfillCursorDate"> | null,
   options?: SearchWindowOptions
 ): AssemblySearchWindow[] {
+  if (options?.latestDateOnly) {
+    return [
+      {
+        label: "recent",
+        startDate: cutoffDate,
+        endDate: cutoffDate
+      }
+    ];
+  }
+
   const yesterday = shiftIsoDate(cutoffDate, -1);
   const windows: AssemblySearchWindow[] = [];
 

--- a/packages/ingest/src/minutes-summary-policy.ts
+++ b/packages/ingest/src/minutes-summary-policy.ts
@@ -1,0 +1,49 @@
+import { dateInTimeZone } from "./document-mirror.js";
+
+const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidIsoDate(value: string): boolean {
+  if (!isoDatePattern.test(value)) {
+    return false;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year!, month! - 1, day!));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month! - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+export function resolveMinutesSummaryTargetDate(
+  configuredDate: string | undefined,
+  now = new Date()
+): string {
+  const value = configuredDate?.trim();
+  if (!value) {
+    return dateInTimeZone("Asia/Seoul", now);
+  }
+  if (!isValidIsoDate(value)) {
+    throw new Error(
+      `MINUTES_SUMMARY_TARGET_DATE must be a valid YYYY-MM-DD date: ${value}`
+    );
+  }
+  return value;
+}
+
+export function selectPendingMinutesDocuments<
+  T extends { publishedDate: string }
+>(args: {
+  documents: T[];
+  targetDate: string;
+  maxDocuments: number;
+  isCurrent: (document: T) => boolean;
+}): T[] {
+  return args.documents
+    .filter(
+      (document) =>
+        document.publishedDate === args.targetDate && !args.isCurrent(document)
+    )
+    .slice(0, args.maxDocuments);
+}

--- a/packages/ingest/src/scripts/mirror-documents.ts
+++ b/packages/ingest/src/scripts/mirror-documents.ts
@@ -95,6 +95,7 @@ type MirrorConfig = {
   backfillWindowsPerRun: number;
   skipRecent: boolean;
   retryExistingOnly: boolean;
+  latestDateOnly: boolean;
   includeAppendices: boolean;
   serviceInfId?: string;
   serviceInfSeq: number;
@@ -351,6 +352,7 @@ function loadConfig(): MirrorConfig {
     ),
     skipRecent: readBooleanEnv("MIRROR_SKIP_RECENT", false),
     retryExistingOnly: readBooleanEnv("MIRROR_RETRY_EXISTING_ONLY", false),
+    latestDateOnly: readBooleanEnv("MIRROR_LATEST_DATE_ONLY", false),
     includeAppendices: readBooleanEnv("MIRROR_INCLUDE_APPENDICES", true),
     serviceInfId,
     serviceInfSeq: readPositiveInteger("MIRROR_SERVICE_INF_SEQ", 1)
@@ -939,6 +941,7 @@ async function collectAssemblyCandidates(
     {
       backfillCursorDate: config.backfillCursorOverride,
       includeRecent: !config.skipRecent,
+      latestDateOnly: config.latestDateOnly,
       maxBackfillWindows: config.backfillWindowsPerRun
     }
   );
@@ -1687,6 +1690,7 @@ async function collectAssemblyMinutesCatalogCandidates(
     {
       backfillCursorDate: config.backfillCursorOverride,
       includeRecent: !config.skipRecent,
+      latestDateOnly: config.latestDateOnly,
       maxBackfillWindows: config.backfillWindowsPerRun
     }
   );
@@ -2812,6 +2816,7 @@ async function main(): Promise<void> {
           : await collectGenericCandidates(page!, config);
   const transcriptRefreshCandidates =
     !config.retryExistingOnly &&
+    !config.latestDateOnly &&
     (config.mode === "assembly_minutes_search" ||
       config.mode === "assembly_minutes_catalog")
       ? buildTranscriptRefreshCandidates(existingMetadata.byDocumentId)
@@ -2863,7 +2868,9 @@ async function main(): Promise<void> {
 
     if (
       !config.retryExistingOnly &&
-      !isPastDocumentDate(candidate.publishedDate, cutoffDate)
+      (config.latestDateOnly
+        ? candidate.publishedDate !== cutoffDate
+        : !isPastDocumentDate(candidate.publishedDate, cutoffDate))
     ) {
       skippedTodayOrFuture += 1;
       continue;
@@ -3024,15 +3031,17 @@ async function main(): Promise<void> {
     : (config.backfillCursorOverride ??
       existingState?.nextBackfillCursorDate ??
       config.backfillStartDate);
-  const nextBackfillCursorDate = config.retryExistingOnly
-    ? existingState?.nextBackfillCursorDate
-    : resolvePublishedBackfillCursor({
-        proposedCursor: collectionResult.nextBackfillCursorDate,
-        fallbackCursor: previousBackfillCursorDate,
-        skippedWithoutDate,
-        downloadFailures,
-        reachedDownloadLimit
-      });
+  const nextBackfillCursorDate = config.latestDateOnly
+    ? null
+    : config.retryExistingOnly
+      ? existingState?.nextBackfillCursorDate
+      : resolvePublishedBackfillCursor({
+          proposedCursor: collectionResult.nextBackfillCursorDate,
+          fallbackCursor: previousBackfillCursorDate,
+          skippedWithoutDate,
+          downloadFailures,
+          reachedDownloadLimit
+        });
   const latestDiscoveredDocumentDate =
     collectionResult.candidates
       .map((candidate) => candidate.publishedDate)
@@ -3081,12 +3090,15 @@ async function main(): Promise<void> {
     recentWindowEndDate,
     effectiveRecentDays: config.recentDays,
     nextBackfillCursorDate,
-    pendingBackfill: hasPendingBackfill({
-      nextBackfillCursorDate,
-      recentWindowStartDate
-    }),
+    pendingBackfill:
+      !config.latestDateOnly &&
+      hasPendingBackfill({
+        nextBackfillCursorDate,
+        recentWindowStartDate
+      }),
     backfillAdvanced:
       !config.retryExistingOnly &&
+      !config.latestDateOnly &&
       Boolean(
         nextBackfillCursorDate &&
         nextBackfillCursorDate > previousBackfillCursorDate

--- a/packages/ingest/src/scripts/summarize-minutes.ts
+++ b/packages/ingest/src/scripts/summarize-minutes.ts
@@ -23,6 +23,10 @@ import {
   type MinutesSummaryMember
 } from "../minutes-summarization.js";
 import {
+  resolveMinutesSummaryTargetDate,
+  selectPendingMinutesDocuments
+} from "../minutes-summary-policy.js";
+import {
   isOfficialAssemblyMinutesViewerUrl,
   type AssemblyMinutesTranscript
 } from "../minutes-transcript.js";
@@ -49,6 +53,7 @@ type SummaryConfig = {
   maxGroups: number;
   concurrency: number;
   requestTimeoutMs: number;
+  targetDate: string;
 };
 
 type SummaryState = {
@@ -56,6 +61,7 @@ type SummaryState = {
   modelId: string;
   promptVersion: string;
   sourceKind: "official_minutes_transcript";
+  targetDate: string;
   documentsVisited: number;
   documentsCompleted: number;
   groupsSummarized: number;
@@ -107,15 +113,18 @@ function loadConfig(): SummaryConfig {
     endpoint:
       process.env.MINUTES_SUMMARY_ENDPOINT?.trim() ||
       "http://127.0.0.1:8080/v1/chat/completions",
-    maxDocuments: readPositiveInteger("MINUTES_SUMMARY_MAX_DOCUMENTS", 1),
-    maxGroups: readPositiveInteger("MINUTES_SUMMARY_MAX_GROUPS", 8),
+    maxDocuments: readPositiveInteger("MINUTES_SUMMARY_MAX_DOCUMENTS", 20),
+    maxGroups: readPositiveInteger("MINUTES_SUMMARY_MAX_GROUPS", 160),
     concurrency: Math.min(
-      readPositiveInteger("MINUTES_SUMMARY_CONCURRENCY", 2),
+      readPositiveInteger("MINUTES_SUMMARY_CONCURRENCY", 4),
       8
     ),
     requestTimeoutMs: readPositiveInteger(
       "MINUTES_SUMMARY_REQUEST_TIMEOUT_MS",
       60_000
+    ),
+    targetDate: resolveMinutesSummaryTargetDate(
+      process.env.MINUTES_SUMMARY_TARGET_DATE
     )
   };
 }
@@ -359,28 +368,30 @@ async function main(): Promise<void> {
       officialProfileUrl: member.officialProfileUrl ?? null
     })
   );
-  const candidateDocuments = documentIndex.items.filter(isTranscriptDocument);
+  const allTranscriptDocuments =
+    documentIndex.items.filter(isTranscriptDocument);
+  const candidateDocuments = allTranscriptDocuments.filter(
+    (item) => item.publishedDate === config.targetDate
+  );
   const artifactByDocumentId = new Map(
     (await loadAllArtifacts(config)).map((artifact) => [
       artifact.documentId,
       artifact
     ])
   );
-  const pendingDocuments = candidateDocuments
-    .filter(
-      (item) =>
-        !isCurrentSummaryArtifact(
-          item,
-          artifactByDocumentId.get(item.documentId),
-          config
-        )
-    )
-    .sort((left, right) =>
-      right.publishedDate.localeCompare(left.publishedDate)
-    )
-    .slice(0, config.maxDocuments);
+  const pendingDocuments = selectPendingMinutesDocuments({
+    documents: candidateDocuments,
+    targetDate: config.targetDate,
+    maxDocuments: config.maxDocuments,
+    isCurrent: (item) =>
+      isCurrentSummaryArtifact(
+        item,
+        artifactByDocumentId.get(item.documentId),
+        config
+      )
+  });
   const currentArtifacts = () =>
-    candidateDocuments.flatMap((item) => {
+    allTranscriptDocuments.flatMap((item) => {
       const artifact = artifactByDocumentId.get(item.documentId);
       return artifact?.sourceContentSha256 === item.transcriptContentSha256
         ? [artifact]
@@ -405,6 +416,7 @@ async function main(): Promise<void> {
         modelId: config.modelId,
         promptVersion: MINUTES_SUMMARY_PROMPT_VERSION,
         sourceKind: "official_minutes_transcript",
+        targetDate: config.targetDate,
         documentsVisited: 0,
         documentsCompleted: 0,
         groupsSummarized: 0,
@@ -587,7 +599,7 @@ async function main(): Promise<void> {
     modelId: config.modelId,
     promptVersion: MINUTES_SUMMARY_PROMPT_VERSION,
     members,
-    artifacts: candidateDocuments.flatMap((item) => {
+    artifacts: allTranscriptDocuments.flatMap((item) => {
       const artifact = artifactByDocumentId.get(item.documentId);
       return artifact?.sourceContentSha256 === item.transcriptContentSha256
         ? [artifact]
@@ -653,6 +665,7 @@ async function main(): Promise<void> {
     modelId: config.modelId,
     promptVersion: MINUTES_SUMMARY_PROMPT_VERSION,
     sourceKind: "official_minutes_transcript",
+    targetDate: config.targetDate,
     documentsVisited: pendingDocuments.length,
     documentsCompleted,
     groupsSummarized,

--- a/tests/ingest/document-mirror.test.ts
+++ b/tests/ingest/document-mirror.test.ts
@@ -998,6 +998,31 @@ describe("document mirror helpers", () => {
     ]);
   });
 
+  it("builds a single same-day window when historical backfill is disabled", () => {
+    expect(
+      buildAssemblySearchWindows(
+        "2026-08-04",
+        {
+          recentDays: 30,
+          backfillStartDate: "2024-05-30",
+          backfillDays: 7
+        },
+        {
+          nextBackfillCursorDate: "2024-05-30"
+        },
+        {
+          latestDateOnly: true
+        }
+      )
+    ).toEqual([
+      {
+        label: "recent",
+        startDate: "2026-08-04",
+        endDate: "2026-08-04"
+      }
+    ]);
+  });
+
   it("advances the property backfill cursor to the end of the last expanded window", () => {
     const windows = buildAssemblySearchWindows(
       "2024-08-31",

--- a/tests/ingest/minutes-incremental-workflow.test.ts
+++ b/tests/ingest/minutes-incremental-workflow.test.ts
@@ -8,22 +8,19 @@ function readRepositoryFile(path: string): string {
 }
 
 describe("incremental minutes workflows", () => {
-  it("keeps document mirroring in bounded, resumable runs", () => {
+  it("mirrors only the Korean calendar date without historical backfill", () => {
     const workflow = readRepositoryFile(
       ".github/workflows/mirror-documents.yml"
     );
 
-    expect(workflow).toContain('default: "500"');
-    expect(workflow).toContain(
-      "MIRROR_CATCHUP_WINDOWS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.backfill_windows || vars.MIRROR_CATCHUP_WINDOWS_PER_RUN || '2' }}"
-    );
+    expect(workflow).toContain('default: "20"');
     expect(workflow).toContain("timeout-minutes: 60");
     expect(workflow).toContain("MIRROR_MODE: assembly_minutes_catalog");
     expect(workflow).toContain(
       "MIRROR_DOWNLOAD_CONCURRENCY: ${{ vars.MIRROR_DOWNLOAD_CONCURRENCY || '4' }}"
     );
     expect(workflow).toContain(
-      "MIRROR_MAX_DOWNLOADS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_downloads || vars.MIRROR_MAX_DOWNLOADS || '500' }}"
+      "MIRROR_MAX_DOWNLOADS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_downloads || vars.MIRROR_MAX_DOWNLOADS || '20' }}"
     );
     expect(workflow).toContain('MIRROR_TIMEOUT_MS: "60000"');
     expect(workflow).toContain('MIRROR_INCLUDE_APPENDICES: "false"');
@@ -31,13 +28,11 @@ describe("incremental minutes workflows", () => {
     expect(workflow).toContain(
       "MIRROR_RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}"
     );
+    expect(workflow).toContain('MIRROR_LATEST_DATE_ONLY: "true"');
     expect(workflow).toContain("Validate indexed minutes repair");
     expect(workflow).toContain("Validate indexed repair configuration");
     expect(workflow).toContain(
       "Indexed minutes repair requires DATA_REPO and DATA_REPO_PAT."
-    );
-    expect(workflow).toContain(
-      '-f retry_existing_only="${MIRROR_RETRY_EXISTING_ONLY}"'
     );
     expect(workflow).toContain(
       "RETRY_EXISTING_ONLY: ${{ inputs.retry_existing_only && 'true' || 'false' }}"
@@ -50,7 +45,12 @@ describe("incremental minutes workflows", () => {
     );
     expect(workflow).toContain("Start minutes summaries");
     expect(workflow).toContain("gh workflow run summarize-minutes.yml");
-    expect(workflow).toContain("Continue pending minutes backfill");
+    expect(workflow).toContain(
+      '-f target_date="${{ steps.mirror-progress.outputs.cutoff_date }}"'
+    );
+    expect(workflow).not.toContain("Continue pending minutes backfill");
+    expect(workflow).not.toContain("backfill_start_date:");
+    expect(workflow).not.toContain("backfill_windows:");
     expect(workflow).toContain("group: published-data-${{ vars.DATA_REPO");
     expect(workflow).toContain("queue: max");
     expect(workflow).toContain("Retry failed minutes mirror");
@@ -58,21 +58,30 @@ describe("incremental minutes workflows", () => {
     expect(workflow).toContain('-f retry_attempt="0"');
   });
 
-  it("keeps AI summarization in small checkpointed batches without recursive continuations", () => {
+  it("summarizes one same-day batch with a single data commit", () => {
     const workflow = readRepositoryFile(
       ".github/workflows/summarize-minutes.yml"
     );
 
-    expect(workflow).toContain('default: "1"');
-    expect(workflow).toContain('default: "8"');
+    expect(workflow).toContain('default: "20"');
+    expect(workflow).toContain('default: "160"');
     expect(workflow).toContain(
-      "MINUTES_SUMMARY_CONCURRENCY: ${{ vars.MINUTES_SUMMARY_CONCURRENCY || '2' }}"
+      "MINUTES_SUMMARY_CONCURRENCY: ${{ vars.MINUTES_SUMMARY_CONCURRENCY || '4' }}"
     );
     expect(workflow).toContain(
       "MINUTES_SUMMARY_REQUEST_TIMEOUT_MS: ${{ vars.MINUTES_SUMMARY_REQUEST_TIMEOUT_MS || '60000' }}"
     );
-    expect(workflow).toContain("timeout-minutes: 30");
+    expect(workflow).toContain("timeout-minutes: 60");
+    expect(workflow).toContain("Resolve Korean summary date");
+    expect(workflow).toContain(
+      '.publishedDate == $target_date and (.transcriptRelativePath // "") != ""'
+    );
     expect(workflow).toContain("Commit and push summary changes");
+    expect(
+      workflow.match(
+        /"\$\{GITHUB_WORKSPACE\}\/scripts\/publish-data-repo\.sh"/g
+      )
+    ).toHaveLength(1);
     expect(workflow).not.toContain("Continue pending minutes summaries");
     expect(workflow).toContain("group: published-data-${{ vars.DATA_REPO");
     expect(workflow).toContain("queue: max");
@@ -106,10 +115,10 @@ describe("incremental minutes workflows", () => {
     );
 
     expect(script).toContain(
-      'readPositiveInteger("MINUTES_SUMMARY_MAX_DOCUMENTS", 1)'
+      'readPositiveInteger("MINUTES_SUMMARY_MAX_DOCUMENTS", 20)'
     );
     expect(script).toContain(
-      'readPositiveInteger("MINUTES_SUMMARY_MAX_GROUPS", 8)'
+      'readPositiveInteger("MINUTES_SUMMARY_MAX_GROUPS", 160)'
     );
     expect(script).toContain(
       '"MINUTES_SUMMARY_REQUEST_TIMEOUT_MS",\n      60_000'

--- a/tests/ingest/minutes-summary-policy.test.ts
+++ b/tests/ingest/minutes-summary-policy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveMinutesSummaryTargetDate,
+  selectPendingMinutesDocuments
+} from "../../packages/ingest/src/minutes-summary-policy.js";
+
+describe("minutes summary policy", () => {
+  it("resolves the target date in Korea", () => {
+    expect(
+      resolveMinutesSummaryTargetDate(
+        undefined,
+        new Date("2026-08-03T15:30:00.000Z")
+      )
+    ).toBe("2026-08-04");
+    expect(resolveMinutesSummaryTargetDate("2026-08-02")).toBe("2026-08-02");
+    expect(() => resolveMinutesSummaryTargetDate("2026-02-30")).toThrow(
+      "valid YYYY-MM-DD"
+    );
+  });
+
+  it("selects only unsummarized documents from the target date", () => {
+    const documents = [
+      { documentId: "today-current", publishedDate: "2026-08-04" },
+      { documentId: "today-first", publishedDate: "2026-08-04" },
+      { documentId: "today-second", publishedDate: "2026-08-04" },
+      { documentId: "historical", publishedDate: "2026-08-03" }
+    ];
+
+    expect(
+      selectPendingMinutesDocuments({
+        documents,
+        targetDate: "2026-08-04",
+        maxDocuments: 1,
+        isCurrent: (document) => document.documentId === "today-current"
+      })
+    ).toEqual([{ documentId: "today-first", publishedDate: "2026-08-04" }]);
+  });
+});


### PR DESCRIPTION
## What changed
- restrict the scheduled minutes mirror to the current Korean calendar date
- remove historical backfill inputs and recursive backfill dispatches
- trigger one summary run for that exact mirror date
- process up to 20 same-day documents and 160 member-agenda groups with concurrency 4
- publish the batch through one data-repository commit
- skip local model startup when no same-day transcript exists
- preserve already published historical summaries without adding old documents to the pending queue

## Why
The previous workflow retained a large historical backlog and could repeatedly publish small batches. The intended policy is to keep current-day minutes fresh without spending Actions time on past minutes or starving Pages deployments.

## Validation
- `npm run typecheck`
- `npm test` (64 files, 333 tests)
- `npm run lint`
- `npm run format:check`
- `npm run build` (298 static member pages generated)
- focused date-boundary and workflow tests
- `git diff --check`