### PR TITLE
Fix stale minutes summary selection

### DIFF
--- a/.github/workflows/summarize-minutes.yml
+++ b/.github/workflows/summarize-minutes.yml
@@ -80,14 +80,13 @@ jobs:
           echo "MINUTES_SUMMARY_TARGET_DATE=${TARGET_DATE}" >> "${GITHUB_ENV}"
           echo "value=${TARGET_DATE}" >> "${GITHUB_OUTPUT}"
 
-      - name: Detect mirrored transcript inputs
+      - name: Detect pending transcript inputs
         id: transcript-inputs
         if: env.DATA_REPO != '' && env.DATA_REPO_PAT != ''
+        env:
+          DATA_REPO_DIR: published-data
         run: |
-          if jq -e \
-            --arg target_date "${MINUTES_SUMMARY_TARGET_DATE}" \
-            'any(.items[]; .publishedDate == $target_date and (.transcriptRelativePath // "") != "")' \
-            published-data/raw/index/document_index.json >/dev/null; then
+          if [ "$(npm run --silent summarize:minutes --workspace @lawmaker-monitor/ingest -- --check-pending)" = "true" ]; then
             echo "available=true" >> "${GITHUB_OUTPUT}"
           else
             echo "available=false" >> "${GITHUB_OUTPUT}"

--- a/packages/ingest/src/minutes-summary-policy.ts
+++ b/packages/ingest/src/minutes-summary-policy.ts
@@ -41,9 +41,24 @@ export function selectPendingMinutesDocuments<
   isCurrent: (document: T) => boolean;
 }): T[] {
   return args.documents
+    .map((document, index) => ({ document, index }))
     .filter(
-      (document) =>
-        document.publishedDate === args.targetDate && !args.isCurrent(document)
+      ({ document }) =>
+        document.publishedDate <= args.targetDate && !args.isCurrent(document)
     )
+    .sort((left, right) => {
+      const leftIsTarget = left.document.publishedDate === args.targetDate;
+      const rightIsTarget = right.document.publishedDate === args.targetDate;
+      if (leftIsTarget !== rightIsTarget) {
+        return leftIsTarget ? -1 : 1;
+      }
+
+      return (
+        right.document.publishedDate.localeCompare(
+          left.document.publishedDate
+        ) || left.index - right.index
+      );
+    })
+    .map(({ document }) => document)
     .slice(0, args.maxDocuments);
 }

--- a/packages/ingest/src/scripts/summarize-minutes.ts
+++ b/packages/ingest/src/scripts/summarize-minutes.ts
@@ -371,7 +371,7 @@ async function main(): Promise<void> {
   const allTranscriptDocuments =
     documentIndex.items.filter(isTranscriptDocument);
   const candidateDocuments = allTranscriptDocuments.filter(
-    (item) => item.publishedDate === config.targetDate
+    (item) => item.publishedDate <= config.targetDate
   );
   const artifactByDocumentId = new Map(
     (await loadAllArtifacts(config)).map((artifact) => [
@@ -390,6 +390,10 @@ async function main(): Promise<void> {
         config
       )
   });
+  if (process.argv.includes("--check-pending")) {
+    process.stdout.write(`${pendingDocuments.length > 0}\n`);
+    return;
+  }
   const currentArtifacts = () =>
     allTranscriptDocuments.flatMap((item) => {
       const artifact = artifactByDocumentId.get(item.documentId);

--- a/tests/ingest/minutes-incremental-workflow.test.ts
+++ b/tests/ingest/minutes-incremental-workflow.test.ts
@@ -58,7 +58,7 @@ describe("incremental minutes workflows", () => {
     expect(workflow).toContain('-f retry_attempt="0"');
   });
 
-  it("summarizes one same-day batch with a single data commit", () => {
+  it("prioritizes same-day minutes and catches up with a single data commit", () => {
     const workflow = readRepositoryFile(
       ".github/workflows/summarize-minutes.yml"
     );
@@ -73,9 +73,8 @@ describe("incremental minutes workflows", () => {
     );
     expect(workflow).toContain("timeout-minutes: 60");
     expect(workflow).toContain("Resolve Korean summary date");
-    expect(workflow).toContain(
-      '.publishedDate == $target_date and (.transcriptRelativePath // "") != ""'
-    );
+    expect(workflow).toContain("Detect pending transcript inputs");
+    expect(workflow).toContain("--check-pending");
     expect(workflow).toContain("Commit and push summary changes");
     expect(
       workflow.match(

--- a/tests/ingest/minutes-summary-policy.test.ts
+++ b/tests/ingest/minutes-summary-policy.test.ts
@@ -19,21 +19,28 @@ describe("minutes summary policy", () => {
     );
   });
 
-  it("selects only unsummarized documents from the target date", () => {
+  it("prioritizes the target date, then catches up from newest pending documents", () => {
     const documents = [
       { documentId: "today-current", publishedDate: "2026-08-04" },
       { documentId: "today-first", publishedDate: "2026-08-04" },
       { documentId: "today-second", publishedDate: "2026-08-04" },
-      { documentId: "historical", publishedDate: "2026-08-03" }
+      { documentId: "historical", publishedDate: "2026-08-03" },
+      { documentId: "older", publishedDate: "2026-08-02" },
+      { documentId: "future", publishedDate: "2026-08-05" }
     ];
 
     expect(
       selectPendingMinutesDocuments({
         documents,
         targetDate: "2026-08-04",
-        maxDocuments: 1,
+        maxDocuments: 4,
         isCurrent: (document) => document.documentId === "today-current"
       })
-    ).toEqual([{ documentId: "today-first", publishedDate: "2026-08-04" }]);
+    ).toEqual([
+      { documentId: "today-first", publishedDate: "2026-08-04" },
+      { documentId: "today-second", publishedDate: "2026-08-04" },
+      { documentId: "historical", publishedDate: "2026-08-03" },
+      { documentId: "older", publishedDate: "2026-08-02" }
+    ]);
   });
 });


### PR DESCRIPTION
## What changes\n- Prioritize the requested Korean-calendar date, then select newest pending minutes for bounded catch-up.\n- Detect actual pending work before starting the local model.\n- Preserve one data commit per run and no success-path recursive dispatch.\n\n## Verification\n- npm test -- tests/ingest/minutes-summary-policy.test.ts tests/ingest/minutes-incremental-workflow.test.ts tests/ingest/minutes-summarization.test.ts tests/ingest/document-mirror.test.ts\n- npm run build --workspace @lawmaker-monitor/schemas\n- npm run build --workspace @lawmaker-monitor/ingest\n- Public data preflight: 1,800 docs / 1,798 transcripts / newest 2026-07-30 => pending=true.