### PR TITLE
Avoid retrying complete minutes summaries

### DIFF
--- a/packages/ingest/src/scripts/summarize-minutes.ts
+++ b/packages/ingest/src/scripts/summarize-minutes.ts
@@ -171,7 +171,7 @@ function isTranscriptDocument(
   );
 }
 
-function isCurrentSummaryArtifact(
+export function isCurrentSummaryArtifact(
   item: MirroredDocumentIndexItem & {
     transcriptContentSha256: string;
   },
@@ -183,10 +183,7 @@ function isCurrentSummaryArtifact(
     artifact.sourceKind === "official_minutes_transcript" &&
     artifact.sourceContentSha256 === item.transcriptContentSha256 &&
     artifact.modelId === config.modelId &&
-    artifact.promptVersion === MINUTES_SUMMARY_PROMPT_VERSION &&
-    artifact.summaries.every((summary) =>
-      isPublishableMinutesSummary(summary.summary)
-    )
+    artifact.promptVersion === MINUTES_SUMMARY_PROMPT_VERSION
   );
 }
 

--- a/tests/ingest/minutes-summary-completion.test.ts
+++ b/tests/ingest/minutes-summary-completion.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isPublishableMinutesSummary,
+  MINUTES_SUMMARY_PROMPT_VERSION,
+  type MinutesDocumentSummaryArtifact
+} from "../../packages/ingest/src/minutes-summarization.js";
+import { isCurrentSummaryArtifact } from "../../packages/ingest/src/scripts/summarize-minutes.js";
+
+import type { MirroredDocumentIndexItem } from "../../packages/ingest/src/document-mirror.js";
+
+describe("minutes summary completion", () => {
+  it("does not retry a complete artifact only because an excluded short excerpt remains", () => {
+    const document = {
+      documentId: "minutes-1",
+      transcriptContentSha256: "transcript-sha"
+    } as MirroredDocumentIndexItem & {
+      transcriptContentSha256: string;
+    };
+    const artifact = {
+      complete: true,
+      sourceKind: "official_minutes_transcript",
+      sourceContentSha256: "transcript-sha",
+      modelId: "test-model",
+      promptVersion: MINUTES_SUMMARY_PROMPT_VERSION,
+      summaries: [{ summary: "다 우리는 준비했어요." }]
+    } as unknown as MinutesDocumentSummaryArtifact;
+
+    expect(isPublishableMinutesSummary(artifact.summaries[0]!.summary)).toBe(
+      false
+    );
+    expect(
+      isCurrentSummaryArtifact(document, artifact, { modelId: "test-model" })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Fix\nA complete artifact could be selected forever when it contained a short excerpt that is intentionally excluded from member exports. Completion now follows source/model/prompt provenance and the artifact completion flag; publishability remains enforced at export time.\n\n## Evidence\n- Canary #32287980928 detected and summarized pending work, then exposed the repeated completed artifact.\n- npm test -- tests/ingest/minutes-summary-completion.test.ts tests/ingest/minutes-summary-policy.test.ts tests/ingest/minutes-incremental-workflow.test.ts tests/ingest/minutes-summarization.test.ts tests/ingest/document-mirror.test.ts (64 passed)\n- npm run build --workspace @lawmaker-monitor/ingest